### PR TITLE
Clean up structopt settings and add ColoredHelp

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use futures::prelude::*;
 use http::header::{HeaderName, HeaderValue};
 use std::io::Read;
+use structopt::clap::AppSettings;
 use structopt::StructOpt;
 
 mod client;
@@ -20,7 +21,11 @@ impl std::str::FromStr for ParseDuration {
 }
 
 #[derive(StructOpt)]
-#[structopt(version = clap::crate_version!(), author = clap::crate_authors!(), about = "Ohayou(おはよう), HTTP load generator, inspired by rakyll/hey with tui animation.", global_setting = clap::AppSettings::DeriveDisplayOrder)]
+#[structopt(
+    author,
+    about,
+    global_settings = &[AppSettings::ColoredHelp, AppSettings::DeriveDisplayOrder]
+)]
 struct Opts {
     #[structopt(help = "Target URL.")]
     url: http::Uri,


### PR DESCRIPTION
The information from `author` and `about` is automatically fetched but it still needs to be declared. I also suggest you add colored help as it's very pretty:

![image](https://user-images.githubusercontent.com/1664/80510261-c4dc2a80-897a-11ea-9a97-f7c51003cd1d.png)
