### PR TITLE
Add instruction for macOS via brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This program is built on stable Rust.
 ## On Arch Linux
 
     yay -S oha
+    
+## On macOS (Homebrew)
+
+    brew install oha
 
 # Platform
 


### PR DESCRIPTION
With https://github.com/Homebrew/homebrew-core/pull/53850, you can now install oha via brew.