### PR TITLE
Add support for --connect-to to override host and port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add --connect-to option to override DNS for a given host+port, similar to curl
+
 # 0.4.2 (2020-10-06)
 
 - Speed up on WSL Ubuntu 20.4
@@ -7,4 +9,4 @@
 # 0.4.1 (2020-07-28)
 
 - Support -q 0 option for unlimited qps
-- Fix performance on limmiting query/second
+- Fix performance on limiting query/second

--- a/src/client.rs
+++ b/src/client.rs
@@ -39,7 +39,7 @@ impl RequestResult {
 struct DNS {
     // To pick a random address from DNS.
     rng: rand::rngs::StdRng,
-    connect_to: Vec<ConnectToEntry>,
+    connect_to: Arc<Vec<ConnectToEntry>>,
     resolver: Arc<
         trust_dns_resolver::AsyncResolver<
             trust_dns_resolver::name_server::GenericConnection,
@@ -94,7 +94,7 @@ pub struct ClientBuilder {
     pub redirect_limit: usize,
     /// always discard when used a connection.
     pub disable_keepalive: bool,
-    pub connect_to: Vec<ConnectToEntry>,
+    pub connect_to: Arc<Vec<ConnectToEntry>>,
     pub resolver: Arc<
         trust_dns_resolver::AsyncResolver<
             trust_dns_resolver::name_server::GenericConnection,

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,7 @@ async fn main() -> anyhow::Result<()> {
         redirect_limit: opts.redirect,
         disable_keepalive: opts.disable_keepalive,
         insecure: opts.insecure,
-        connect_to: opts.connect_to,
+        connect_to: Arc::new(opts.connect_to),
     };
     if let Some(duration) = opts.duration.take() {
         match opts.query_per_second {

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ async fn main() -> anyhow::Result<()> {
     let headers = {
         let mut headers: http::header::HeaderMap = Default::default();
 
-        // Accepct all
+        // Accept all
         headers.insert(
             http::header::ACCEPT,
             http::header::HeaderValue::from_static("*/*"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ impl FromStr for ConnectToEntry {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let tokens: Vec<&str> = s.split(":").collect();
+        let tokens: Vec<&str> = s.split(':').collect();
         if tokens.len() != 4 {
             return Err("must have 4 items separated by colons");
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -107,20 +107,18 @@ async fn redirect(n: usize, is_relative: bool, limit: usize) -> bool {
         if x == n {
             tx.send(()).unwrap();
             http::Response::builder().status(200).body("OK").unwrap()
+        } else if is_relative {
+            http::Response::builder()
+                .status(301)
+                .header("Location", format!("/{}", x + 1))
+                .body("OK")
+                .unwrap()
         } else {
-            if is_relative {
-                http::Response::builder()
-                    .status(301)
-                    .header("Location", format!("/{}", x + 1))
-                    .body("OK")
-                    .unwrap()
-            } else {
-                http::Response::builder()
-                    .status(301)
-                    .header("Location", format!("http://localhost:{}/{}", port, x + 1))
-                    .body("OK")
-                    .unwrap()
-            }
+            http::Response::builder()
+                .status(301)
+                .header("Location", format!("http://localhost:{}/{}", port, x + 1))
+                .body("OK")
+                .unwrap()
         }
     });
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -141,6 +141,38 @@ async fn redirect(n: usize, is_relative: bool, limit: usize) -> bool {
     rx.try_recv().is_ok()
 }
 
+async fn get_host_with_connect_to(host: &'static str) -> String {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let report_headers =
+        warp::get()
+            .and(warp::filters::header::header("host"))
+            .map(move |host: String| {
+                tx.send(host).unwrap();
+                "Hello World"
+            });
+
+    let _guard = PORT_LOCK.lock().unwrap();
+    let port = get_port::get_port().unwrap();
+    tokio::spawn(warp::serve(report_headers).run(([127, 0, 0, 1], port)));
+    // It's not guaranteed that the port is used here.
+    // So we can't drop guard here.
+
+    tokio::task::spawn_blocking(move || {
+        Command::cargo_bin("oha")
+            .unwrap()
+            .args(&["-n", "1", "--no-tui"])
+            .arg(format!("http://{}/", host))
+            .arg("--connect-to")
+            .arg(format!("{}:80:localhost:{}", host, port))
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    rx.try_recv().unwrap()
+}
+
 #[tokio::test]
 async fn test_enable_compression_default() {
     let header = get_header_body(&[]).await.0;
@@ -242,6 +274,14 @@ async fn test_query() {
         get_query("index?a=b&c=d").await,
         "index?a=b&c=d".to_string()
     );
+}
+
+#[tokio::test]
+async fn test_connect_to() {
+    assert_eq!(
+        get_host_with_connect_to("invalid.example.org").await,
+        "invalid.example.org"
+    )
 }
 
 #[tokio::test]


### PR DESCRIPTION
This closes #115.

The option has help text provided by structopt and behaves like curl's `--connect-to`.