### PR TITLE
Manually bump `resolv-conf` to `master` at rev `83c0f25`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "libc",
  "native-tls",
  "rand 0.7.3",
+ "resolv-conf",
  "rlimit",
  "structopt",
  "thiserror",
@@ -1523,8 +1524,7 @@ dependencies = [
 [[package]]
 name = "resolv-conf"
 version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
+source = "git+https://github.com/tailhook/resolv-conf?rev=83c0f25ebcb0615550488692c5213ca1ae4acd8f#83c0f25ebcb0615550488692c5213ca1ae4acd8f"
 dependencies = [
  "hostname",
  "quick-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tokio-native-tls = "0.1.0"
 rand = "0.7"
 trust-dns-resolver = "0.19.3"
 base64 = "0.13.0"
+resolv-conf = "0.6.3"
 
 
 [target.'cfg(unix)'.dependencies]
@@ -47,3 +48,6 @@ get-port = "3"
 lazy_static = "1.4.0"
 bytes = "0.5.4"
 http = "0.2"
+
+[patch.crates-io]
+resolv-conf = { git = 'https://github.com/tailhook/resolv-conf', rev = '83c0f25ebcb0615550488692c5213ca1ae4acd8f' }


### PR DESCRIPTION
This fixes the parsing of `/etc/resolv.conf` with `options trust-ad`
which is e.g. used in `systemd-resolved-v246`[1].

Refs hatoo#118

[1] systemd/systemd@a742f98