### PR TITLE
Add minimal-versions to Github CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,8 +71,8 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-  minimal-version:
-    name: minimal-version
+  minimal-versions:
+    name: minimal-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,3 +70,23 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  minimal-version:
+    name: minimal-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2020-09-21
+          override: true
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+      - name: "check -Z minimal-versions"
+        run: |
+          # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
+          # from determining minimal versions based on dev-dependencies.
+          cargo hack --remove-dev-deps
+          # Update Cargo.lock to minimal version dependencies.
+          cargo update -Z minimal-versions
+          cargo hack check --no-dev-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 [dependencies]
 structopt = "0.3"
 tokio = { version = "1.0.1", features = ["full"] }
-anyhow = "1"
+anyhow = "1.0.38"
 thiserror = "1.0.16"
 futures = "0.3.12"
 average = "0.10.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ structopt = "0.3"
 tokio = { version = "1.0.1", features = ["full"] }
 anyhow = "1"
 thiserror = "1.0.16"
-futures = "0.3"
+futures = "0.3.12"
 average = "0.10.4"
 float-ord = "0.2.0"
 byte-unit = "4.0.8"


### PR DESCRIPTION
Resolves #127. I spent awhile figuring out how to get this to work for some of my own projects. This adds a job that will attempt to check your project using the nightly feature of `-Z minimal-versions`. The challenge is that this job fails (as with many crates), and you have to either submit PR requests to transient dependencies or update your own. 

- It looks like futures 0.3.1 is being pulled in (latest available being 0.3.12), which is missing a macro from future_utils. Not sure when that macro got introduced, but if you update to `0.3.12` of futures it will move on to an error with anyhow. 
- It looks like an older anyhow version is pulled in that is missing functionality, so bumping to the latest of 1.0.38 will fix that and result in passing tests.

Fails on futures:

<img width="1224" alt="Screen Shot 2021-01-15 at 11 58 37 AM" src="https://user-images.githubusercontent.com/2481802/104761855-1c990c80-5729-11eb-8499-e23b63de444d.png">

Fixing that by using `0.3.12` in Cargo.toml, will fail in this way with anyhow:

<img width="1548" alt="Screen Shot 2021-01-15 at 12 07 05 PM" src="https://user-images.githubusercontent.com/2481802/104762596-3d159680-572a-11eb-8734-31a62eea6e07.png">

Updating both dependencies looks like you now pass minimal versions check.
