### PR TITLE
Fix Typo (probrem -> problem)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ USAGE:
     oha [FLAGS] [OPTIONS] <url>
 
 FLAGS:
-        --latency-correction     Correct latency to avoid coordinated omission probrem. It's ignored if -q is not set.
+        --latency-correction     Correct latency to avoid coordinated omission problem. It's ignored if -q is not set.
         --no-tui                 No realtime tui
         --disable-compression    Disable compression.
         --disable-keepalive      Disable keep-alive, prevents re-use of TCP connections between different HTTP requests.

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ Examples: -z 10s -z 3m.",
     #[structopt(help = "Rate limit for all, in queries per second (QPS)", short = "q")]
     query_per_second: Option<usize>,
     #[structopt(
-        help = "Correct latency to avoid coordinated omission probrem. It's ignored if -q is not set.",
+        help = "Correct latency to avoid coordinated omission problem. It's ignored if -q is not set.",
         long = "latency-correction"
     )]
     latency_correction: bool,


### PR DESCRIPTION
Fix a small typo found by using the `--latency-correction` feature.