### PR TITLE
Add --unix-socket for non-HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add `--unix-socket` on `unix` profiles for HTTP. #220
 - Fix tui to not requiring True Color. #209
 
 # 0.5.7 (2023-02-25)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Options:
       --insecure                     Accept invalid certs.
       --connect-to <CONNECT_TO>      Override DNS resolution and default port numbers with strings like 'example.org:443:localhost:8443'
       --disable-color                Disable the color scheme.
+      --unix-socket <UNIX_SOCKET>    Connect to a unix socket instead of the domain in the URL. Only for non-HTTPS URLs.
   -h, --help                         Print help
   -V, --version                      Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,12 @@ Examples: -z 10s -z 3m.",
     connect_to: Vec<ConnectToEntry>,
     #[clap(help = "Disable the color scheme.", long = "disable-color")]
     disable_color: bool,
+    #[cfg(unix)]
+    #[clap(
+        help = "Connect to a unix socket instead of the domain in the URL. Only for non-HTTPS URLs.",
+        long = "unix-socket"
+    )]
+    unix_socket: Option<std::path::PathBuf>,
 }
 
 /// An entry specified by `connect-to` to override DNS resolution and default
@@ -370,6 +376,8 @@ async fn main() -> anyhow::Result<()> {
         disable_keepalive: opts.disable_keepalive,
         insecure: opts.insecure,
         connect_to: Arc::new(opts.connect_to),
+        #[cfg(unix)]
+        unix_socket: opts.unix_socket,
     };
     if let Some(duration) = opts.duration.take() {
         match opts.query_per_second {


### PR DESCRIPTION
I wanted to test a service that exposes a webserver over a UNIX domain socket. I was using `hyperfine` + `curl --unix-socket` and I wanted the stats `oha` provides, so I added the option on UNIX compiles.

LMK if you have any questions or changes. I avoided adding it to HTTPS due to the feature interaction already in place on that method.