### PR TITLE
Fix -H Header parser 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -207,10 +207,10 @@ async fn main() -> anyhow::Result<()> {
             opts.headers
                 .into_iter()
                 .map(|s| {
-                    let header = s.splitn(2, ": ").collect::<Vec<_>>();
+                    let header = s.splitn(2, ':').collect::<Vec<_>>();
                     anyhow::ensure!(header.len() == 2, anyhow::anyhow!("Parse header"));
-                    let name = HeaderName::from_bytes(header[0].as_bytes())?;
-                    let value = HeaderValue::from_str(header[1])?;
+                    let name = HeaderName::from_str(header[0])?;
+                    let value = HeaderValue::from_str(header[1].trim_start_matches(' '))?;
                     Ok::<(HeaderName, HeaderValue), anyhow::Error>((name, value))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -301,6 +301,8 @@ async fn test_enable_compression_default() {
 async fn test_setting_custom_header() {
     let header = get_header_body(&["-H", "foo: bar", "--"]).await.0;
     assert_eq!(header.get("foo").unwrap().to_str().unwrap(), "bar");
+    let header = get_header_body(&["-H", "foo:bar", "--"]).await.0;
+    assert_eq!(header.get("foo").unwrap().to_str().unwrap(), "bar");
 }
 
 #[tokio::test]


### PR DESCRIPTION
fixes #231 

Allow "KEY:VALUE" format