### PR TITLE
Add `user-agent` to request header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,6 +250,14 @@ async fn main() -> anyhow::Result<()> {
                 .collect::<anyhow::Result<Vec<_>>>()?,
         );
 
+        // User agent
+        headers
+            .entry(http::header::USER_AGENT)
+            .or_insert(HeaderValue::from_static(concat!(
+                "oha/",
+                env!("CARGO_PKG_VERSION")
+            )));
+
         if let Some(h) = opts.accept_header {
             headers.insert(http::header::ACCEPT, HeaderValue::from_bytes(h.as_bytes())?);
         }


### PR DESCRIPTION
Quote from https://www.rfc-editor.org/rfc/rfc9110#name-user-agent:
> A user agent SHOULD send a User-Agent header field in each request unless specifically configured not to do so.

Closes #257.