### PR TITLE
save request results into sqlite database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1286,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1659,6 +1680,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2016,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "rlimit",
+ "rusqlite",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -2470,6 +2502,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3560f70f30a0f16d11d01ed078a07740fe6b489667abc7c7b029155d9f21c3d8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ pin-project-lite = "0.2.14"
 http-body-util = "0.1.2"
 hyper-util = { version = "0.1.6", features = ["tokio"] }
 tokio-vsock = { version = "0.5.0", optional = true }
+rusqlite = "0.32.1"
 
 [target.'cfg(unix)'.dependencies]
 rlimit = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ pin-project-lite = "0.2.14"
 http-body-util = "0.1.2"
 hyper-util = { version = "0.1.6", features = ["tokio"] }
 tokio-vsock = { version = "0.5.0", optional = true }
-rusqlite = "0.32.1"
+rusqlite = { version = "0.32.0", features = ["bundled"] }
 
 [target.'cfg(unix)'.dependencies]
 rlimit = "0.10.1"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use rusqlite::Connection;
 
-use crate::client::{ClientError, RequestResult};
+use crate::client::RequestResult;
 
 fn create_db(conn: &Connection) -> Result<usize, rusqlite::Error> {
     conn.execute(
@@ -29,7 +29,7 @@ pub fn store(
 
     let affected_rows =
         request_records
-            .into_iter()
+            .iter()
             .map(|req| {
                 conn.execute(
           "INSERT INTO loadtest (url, duration, status, len_bytes) VALUES (?1, ?2, ?3, ?4)",

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,7 +22,7 @@ pub fn store(
     request_records: &[RequestResult],
 ) -> Result<usize, rusqlite::Error> {
     let mut conn = Connection::open(db_url)?;
-    _ = create_db(&conn);
+    create_db(&conn)?;
 
     let t = conn.transaction()?;
     let affected_rows =

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,65 @@
+use rusqlite::Connection;
+
+use crate::client::{ClientError, RequestResult};
+
+fn create_db(conn: &Connection) -> Result<usize, rusqlite::Error> {
+    conn.execute(
+        "CREATE TABLE loadtest (
+            url TEXT NOT NULL,
+            duration REAL,
+            status INTEGER,
+            len_bytes INTEGER
+        )",
+        (),
+    )
+}
+
+pub fn store(
+    db_url: &str,
+    req_url: String,
+    request_records: &[RequestResult],
+) -> Result<usize, rusqlite::Error> {
+    let conn = Connection::open(db_url)?;
+    _ = create_db(&conn);
+
+    let request_url = req_url
+        .replace("https", "")
+        .replace("http", "")
+        .replace("://", "");
+
+    let affected_rows =
+        request_records
+            .into_iter()
+            .map(|req| {
+                conn.execute(
+          "INSERT INTO loadtest (url, duration, status, len_bytes) VALUES (?1, ?2, ?3, ?4)",
+        (&request_url, req.duration().as_secs_f32(), req.status.as_u16() as u32, req.len_bytes),
+        ).unwrap_or(0)
+            })
+            .sum();
+
+    Ok(affected_rows)
+}
+
+#[cfg(test)]
+mod test_db {
+    use super::*;
+
+    #[test]
+    fn test_store() {
+        let conn = Connection::open_in_memory().unwrap();
+        let _ = create_db(&conn);
+        let test_val = RequestResult {
+            status: hyper::StatusCode::OK,
+            len_bytes: 100,
+            start_latency_correction: None,
+            start: std::time::Instant::now(),
+            connection_time: None,
+            end: std::time::Instant::now(),
+        };
+        let test_vec = vec![test_val.clone(), test_val.clone()];
+        let result = store("test.db", "test.com".to_owned(), &test_vec);
+        assert_eq!(result.unwrap(), 2);
+        std::fs::remove_file("test.db").unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,10 @@ Note: If qps is specified, burst will be ignored",
         long = "stats-success-breakdown"
     )]
     stats_success_breakdown: bool,
-    #[clap(help = "sqlite datebase url E.G test.db", long = "db-url")]
+    #[clap(
+        help = "Write succeeded requests to sqlite database url E.G test.db",
+        long = "db-url"
+    )]
     db_url: Option<String>,
 }
 
@@ -658,6 +661,7 @@ async fn main() -> anyhow::Result<()> {
     )?;
 
     if let Some(db_url) = opts.db_url {
+        eprintln!("Storing results to {db_url}");
         let _ = db::store(&db_url, start, res.success());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -658,7 +658,7 @@ async fn main() -> anyhow::Result<()> {
     )?;
 
     if let Some(db_url) = opts.db_url {
-        let _ = db::store(&db_url, opts.url, res.success());
+        let _ = db::store(&db_url, start, res.success());
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use url::Url;
 use url_generator::UrlGenerator;
 
 mod client;
+mod db;
 mod histogram;
 mod monitor;
 mod printer;
@@ -188,6 +189,8 @@ Note: If qps is specified, burst will be ignored",
         long = "stats-success-breakdown"
     )]
     stats_success_breakdown: bool,
+    #[clap(help = "sqlite datebase url E.G test.db", long = "db-url")]
+    db_url: Option<String>,
 }
 
 /// An entry specified by `connect-to` to override DNS resolution and default
@@ -653,6 +656,10 @@ async fn main() -> anyhow::Result<()> {
         opts.disable_color,
         opts.stats_success_breakdown,
     )?;
+
+    if let Some(db_url) = opts.db_url {
+        let _ = db::store(&db_url, opts.url, res.success());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
can now be invoked with 
```bash
oha <url> --db-url loadtest.db
```
to store the vector of request results into a sqlite db. 

considerations:
* table name:  defaults to loadtest table to avoid another parameter
* there may be other data people may want to keep track of. 

the table looks like this:
```sql
CREATE TABLE loadtest (
            url TEXT NOT NULL,
            duration REAL,
            status INTEGER,
            len_bytes INTEGER,
        )
```

