### PR TITLE
Feature burst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/src/client.rs
+++ b/src/client.rs
@@ -779,7 +779,7 @@ pub async fn work_until_with_qps(
             let (tx, rx) = flume::unbounded();
             tokio::spawn(async move {
                 // Handle via rate till deadline is reached
-                loop {
+                for _ in 0.. {
                     if std::time::Instant::now() > dead_line {
                         break;
                     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -599,7 +599,7 @@ pub async fn work_with_qps(
                     n += rate;
                 }
                 // Handle the remaining tasks
-                if n - n_tasks < rate {
+                if n - n_tasks < rate && n - n_tasks > 0 {
                     tokio::time::sleep(duration).await;
                     for _ in 0..n_tasks - n {
                         tx.send_async(()).await.unwrap();
@@ -672,7 +672,7 @@ pub async fn work_with_qps_latency_correction(
                     n += rate;
                 }
                 // Handle the remaining tasks
-                if n - n_tasks < rate {
+                if n - n_tasks < rate && n - n_tasks > 0 {
                     tokio::time::sleep(duration).await;
                     for _ in 0..n_tasks - n {
                         tx.send_async(std::time::Instant::now()).await.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,7 +483,7 @@ async fn main() -> anyhow::Result<()> {
                     client::work_with_qps_latency_correction(
                         client,
                         result_tx,
-                        qps,
+                        client::QueryLimit::Qps(qps),
                         opts.n_requests,
                         opts.n_workers,
                     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use crossterm::tty::IsTty;
 use futures::prelude::*;
 use http::header::{HeaderName, HeaderValue};
+use humantime::Duration;
 use printer::PrintMode;
 use rand::prelude::*;
 use rand_regex::Regex;
@@ -45,8 +46,28 @@ struct Opts {
 Examples: -z 10s -z 3m.",
         short = 'z'
     )]
-    duration: Option<humantime::Duration>,
-    #[clap(help = "Rate limit for all, in queries per second (QPS)", short = 'q')]
+    duration: Option<Duration>,
+    #[arg(
+        help = "Introduce delay between a predefined number of requests.
+Group: Burst
+Note: If burst is specified, query_per_second will be discarded",
+        long = "burst-delay",
+        group = "burst"
+    )]
+    burst_duration: Option<Duration>,
+    #[arg(
+        help = "Rates of requests for burst
+Group: Burst
+Note: If burst is specified, query_per_second will be discarded",
+        long = "burst-rate",
+        group = "burst"
+    )]
+    burst_requests: Option<usize>,
+    #[clap(
+        help = "Rate limit for all, in queries per second (QPS)
+Note: Query per second will be discarded if burst is specified",
+        short = 'q'
+    )]
     query_per_second: Option<usize>,
     #[clap(
         help = "Generate URL by rand_regex crate but dot is disabled for each query e.g. http://127.0.0.1/[a-z][a-z][0-9]. Currently dynamic scheme, host and port with keep-alive are not works well. See https://docs.rs/rand_regex/latest/rand_regex/struct.Regex.html for details of syntax.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ Note: If qps is specified, burst will be ignored",
     )]
     burst_duration: Option<Duration>,
     #[arg(
-        help = "Rates of requests for burst
+        help = "Rates of requests for burst. Default is 1
 Group: Burst
 Note: If qps is specified, burst will be ignored",
         long = "burst-rate",

--- a/src/main.rs
+++ b/src/main.rs
@@ -489,8 +489,14 @@ async fn main() -> anyhow::Result<()> {
                     )
                     .await
                 } else {
-                    client::work_with_qps(client, result_tx, qps, opts.n_requests, opts.n_workers)
-                        .await
+                    client::work_with_qps(
+                        client,
+                        result_tx,
+                        client::QueryLimit::Qps(qps),
+                        opts.n_requests,
+                        opts.n_workers,
+                    )
+                    .await
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,7 +464,7 @@ async fn main() -> anyhow::Result<()> {
                     client::work_until_with_qps(
                         client,
                         result_tx,
-                        qps,
+                        client::QueryLimit::Qps(qps),
                         start,
                         start + duration.into(),
                         opts.n_workers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -454,7 +454,7 @@ async fn main() -> anyhow::Result<()> {
                     client::work_until_with_qps_latency_correction(
                         client,
                         result_tx,
-                        qps,
+                        client::QueryLimit::Qps(qps),
                         start,
                         start + duration.into(),
                         opts.n_workers,

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,16 +53,14 @@ Examples: -z 10s -z 3m.",
         help = "Introduce delay between a predefined number of requests.
 Group: Burst
 Note: If qps is specified, burst will be ignored",
-        long = "burst-delay",
-        group = "burst"
+        long = "burst-delay"
     )]
     burst_duration: Option<Duration>,
     #[arg(
         help = "Rates of requests for burst. Default is 1
 Group: Burst
 Note: If qps is specified, burst will be ignored",
-        long = "burst-rate",
-        group = "burst"
+        long = "burst-rate"
     )]
     burst_requests: Option<usize>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,13 +446,13 @@ async fn main() -> anyhow::Result<()> {
                     client::work_until(client, result_tx, start + duration.into(), opts.n_workers)
                         .await
                 }
-                Some(duration) => {
+                Some(burst_duration) => {
                     if opts.latency_correction {
                         client::work_until_with_qps_latency_correction(
                             client,
                             result_tx,
                             client::QueryLimit::Burst(
-                                duration.into(),
+                                burst_duration.into(),
                                 opts.burst_requests.unwrap_or(1),
                             ),
                             start,
@@ -465,7 +465,7 @@ async fn main() -> anyhow::Result<()> {
                             client,
                             result_tx,
                             client::QueryLimit::Burst(
-                                duration.into(),
+                                burst_duration.into(),
                                 opts.burst_requests.unwrap_or(1),
                             ),
                             start,
@@ -504,13 +504,13 @@ async fn main() -> anyhow::Result<()> {
         match opts.query_per_second {
             Some(0) | None => match opts.burst_duration {
                 None => client::work(client, result_tx, opts.n_requests, opts.n_workers).await,
-                Some(duration) => {
+                Some(burst_duration) => {
                     if opts.latency_correction {
                         client::work_with_qps_latency_correction(
                             client,
                             result_tx,
                             client::QueryLimit::Burst(
-                                duration.into(),
+                                burst_duration.into(),
                                 opts.burst_requests.unwrap_or(1),
                             ),
                             opts.n_requests,
@@ -522,7 +522,7 @@ async fn main() -> anyhow::Result<()> {
                             client,
                             result_tx,
                             client::QueryLimit::Burst(
-                                duration.into(),
+                                burst_duration.into(),
                                 opts.burst_requests.unwrap_or(1),
                             ),
                             opts.n_requests,


### PR DESCRIPTION
#276 Introducing `burst`:
Using `--burst-duration`: the user can now add a delay between requests. For example: If `-n 10 --burst-duration 2s`, oha will run one request every 2s until it reaches 10s
Adding along with `--burst-requests`: the rate of requests at one point in time the user wants to send. E.g: In the example above `-n 10 --burst-duration 2s --burst-requests 2`, oha will now run 2 requests every 2s
![image](https://github.com/hatoo/oha/assets/88610355/2260c119-b480-4b0a-8604-580c615183b5)

Changes to the code:
```
# client.rs
# Added logic to accept Burst instead 
pub enum QueryLimit {
    Qps(usize),
    Burst(std::time::Duration, usize),
}

# Functions to accept Bursts instead of qps
work_with_qps()
work_with_qps_latency_correction()
work_until_with_qps()
work_until_with_qps_latency_correction()
```

```
# main.rs
# struct Opts: Added `burst_duration` and `burst_requests`
# main function:
if let Some(duration) = opts.duration.take() {
     # Added additional `match` to take in `Burst` as well, not just qps
}
```

```