### PR TITLE
Added a stats-success-breakdown flag for more detailed status code specific response statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Add style and colors to the summary view #64
+- Added a stats-success-breakdown flag for more detailed status code specific response statistics #212
 
 # 0.6.2 (2023-08-12)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,10 +151,10 @@ Note: If qps is specified, burst will be ignored",
     )]
     unix_socket: Option<std::path::PathBuf>,
     #[clap(
-        help = "Count only 2xx status codes for the response time histogram and distribution statistics.",
-        long = "success-stats-only"
+        help = "Include a response status code successful or not successful breakdown for the time histogram and distribution statistics",
+        long = "stats-success-breakdown"
     )]
-    success_stats_only: bool,
+    stats_success_breakdown: bool,
 }
 
 /// An entry specified by `connect-to` to override DNS resolution and default
@@ -372,7 +372,7 @@ async fn main() -> anyhow::Result<()> {
                         }
                         _ = ctrl_c_rx.recv_async() => {
                             // User pressed ctrl-c.
-                            let _ = printer::print_result(&mut std::io::stdout(),print_mode,start, &all, start.elapsed(), opts.disable_color, opts.success_stats_only);
+                            let _ = printer::print_result(&mut std::io::stdout(),print_mode,start, &all, start.elapsed(), opts.disable_color, opts.stats_success_breakdown);
                             std::process::exit(libc::EXIT_SUCCESS);
                         }
                     }
@@ -395,7 +395,7 @@ async fn main() -> anyhow::Result<()> {
                 start,
                 fps: opts.fps,
                 disable_color: opts.disable_color,
-                success_stats_only: opts.success_stats_only,
+                stats_success_breakdown: opts.stats_success_breakdown,
             }
             .monitor(),
         )
@@ -571,7 +571,7 @@ async fn main() -> anyhow::Result<()> {
         &res,
         duration,
         opts.disable_color,
-        opts.success_stats_only,
+        opts.stats_success_breakdown,
     )?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,11 @@ Note: If qps is specified, burst will be ignored",
         long = "unix-socket"
     )]
     unix_socket: Option<std::path::PathBuf>,
+    #[clap(
+        help = "Count only 2xx status codes for the response time histogram and distribution statistics.",
+        long = "success-stats-only"
+    )]
+    success_stats_only: bool,
 }
 
 /// An entry specified by `connect-to` to override DNS resolution and default
@@ -367,7 +372,7 @@ async fn main() -> anyhow::Result<()> {
                         }
                         _ = ctrl_c_rx.recv_async() => {
                             // User pressed ctrl-c.
-                            let _ = printer::print_result(&mut std::io::stdout(),print_mode,start, &all, start.elapsed(), opts.disable_color);
+                            let _ = printer::print_result(&mut std::io::stdout(),print_mode,start, &all, start.elapsed(), opts.disable_color, opts.success_stats_only);
                             std::process::exit(libc::EXIT_SUCCESS);
                         }
                     }
@@ -390,6 +395,7 @@ async fn main() -> anyhow::Result<()> {
                 start,
                 fps: opts.fps,
                 disable_color: opts.disable_color,
+                success_stats_only: opts.success_stats_only,
             }
             .monitor(),
         )
@@ -565,6 +571,7 @@ async fn main() -> anyhow::Result<()> {
         &res,
         duration,
         opts.disable_color,
+        opts.success_stats_only,
     )?;
 
     Ok(())

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -55,7 +55,7 @@ pub struct Monitor {
     // Frame per scond of TUI
     pub fps: usize,
     pub disable_color: bool,
-    pub success_stats_only: bool,
+    pub stats_success_breakdown: bool,
 }
 
 impl Monitor {
@@ -453,7 +453,7 @@ impl Monitor {
                             &all,
                             now - self.start,
                             self.disable_color,
-                            self.success_stats_only,
+                            self.stats_success_breakdown,
                         );
                         std::process::exit(libc::EXIT_SUCCESS);
                     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -55,6 +55,7 @@ pub struct Monitor {
     // Frame per scond of TUI
     pub fps: usize,
     pub disable_color: bool,
+    pub success_stats_only: bool,
 }
 
 impl Monitor {
@@ -452,6 +453,7 @@ impl Monitor {
                             &all,
                             now - self.start,
                             self.disable_color,
+                            self.success_stats_only,
                         );
                         std::process::exit(libc::EXIT_SUCCESS);
                     }


### PR DESCRIPTION
**Edit: This comment is now out of date, see additional comments below**

Added a command line flag `success-stats-only` which when set includes only successful (2xx responses) when measuring the Response time histogram and distribution statistics (as per issue: #212 )

The below example was generated using a backend server which returns slow 5xx responses. The left terminal is running with the default options, and the right terminal has the new flag set. As you can see, the slow 5xx responses are excluded from the right terminal:

![image](https://github.com/hatoo/oha/assets/61805721/0eb65530-bf8b-413c-abcd-c55722e828dd)

The same flag is applied to the JSON equivalent fields.

I did investigate adding a test for this:
- Adding a new `warp` handler to return non 2xx responses for every other request
- Adding a test which runs an oha command with 2 requests, asserting that when the success flag is set only a single response would appear in the output (2nd request would be a 5xx)

Although I stopped as it was a little tricky, and I wanted to see what the initial response to the PR was first.
Can proceed with adding the test if the changes here make sense.
