### PR TITLE
Update Debian/ubuntu/APT install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can optionally build oha against [rustls](https://github.com/rustls/rustls) 
 
 ## On Debian ([Azlux's repository](http://packages.azlux.fr/))
 
-    echo "deb http://packages.azlux.fr/debian/ buster main" | sudo tee /etc/apt/sources.list.d/azlux.list
-    wget -qO - https://azlux.fr/repo.gpg.key | sudo apt-key add -
+    echo "deb [signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian/ stable main" | sudo tee /etc/apt/sources.list.d/azlux.list
+    sudo wget -O /usr/share/keyrings/azlux-archive-keyring.gpg https://azlux.fr/repo.gpg
     apt update
     apt install oha
 


### PR DESCRIPTION
apt-key is deprecated, you no longer need to have gnupg installed on your system to add repositories, and this makes it so that the signing key blast radius (in case of exposure) is reduced, as packages from other repositories cannot be accepted for using this key (the key is scoped by repository, not the case with `apt-key add`)