### PR TITLE
ci: switch from actions-rs to dtolnay for clippy/rustfmt

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,30 +47,21 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - name: Enforce formatting
+        run: cargo fmt --all --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+          components: clippy
+      - name: Linting
+        run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
`actions-rs` is largely unmaintained for a few years. In contrast, dtolnay's actions are maintained and have largely taken the place of actions-rs for many Rust workflows.

This patch switches to dtolnay's versions for Rustfmt and Clippy, but does not touch the other jobs since they are more complex with matrix testing. Note that this also changes from running nightly clippy to stable clippy, which should pass, unlike what we see right now [[1]].

[1]: https://github.com/hatoo/oha/actions/runs/6281404969/job/17059738170