### PR TITLE
Fix Apple silicon binary release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }} --locked --no-default-features --features rustls
       - uses: svenstaro/upx-action@v2
-        if: matrix.target != 'aarch64-unknown-linux-musl'
+        if: matrix.target != 'aarch64-unknown-linux-musl' && matrix.target != 'aarch64-apple-darwin'
         with:
           file: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
       - name: Upload binaries to release


### PR DESCRIPTION
https://github.com/hatoo/oha/issues/267#issuecomment-1694488316

https://github.com/upx/upx/issues/446

oha-macos-arm64 binary seems broken because of upx.

I hope this PR fix it.
Since I don't have Apple Silicon environment, I can't check whether if it works though.