### PR TITLE
Issue 361 - Improve http2 connection error handling

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1098,7 +1098,7 @@ pub async fn work_until(
                                 let should_exit = Arc::new(AtomicBool::new(false));
                                 // Setup the parallel workers for each HTTP2 connection
                                 loop {
-                                    if std::time::Instant::now() > dead_line.into() || should_exit.load(Ordering::Relaxed){
+                                    if std::time::Instant::now() > dead_line.into() || should_exit.load(Ordering::Relaxed) {
                                         break;
                                     }
                                     let futures = (0..n_http2_parallel)


### PR DESCRIPTION
- Partial fix for #361
- ONLY implemented for the `-z 10s` (work_until) case
- TODO:
   - [x] The futures are not aborted when the timer is hit, which will cause long running requests to delay the program exit - this is only due to a borrow/move problem that I cannot figure out
   - [ ] Implement for the non-`work_until` cases
   - [ ] Add a timeout to the TCP socket setup - this appears to be where some of the delay on shutdown is happening if the server closes after startup
   - [ ] Consider adding a delay to the reconnect loop so that it will not try to connect more than 1 time per second per concurrent connection - Without this the connect loop will spin at ~23k connect attempts/second for `-c 20`, for example
- Test cases:
  - Start with the server not running at all (never connects) - Currently this will exit on time - IMPROVED: Previously this would attempt to connect once for each `-c`, fail, and immediately exit - IMPROVED: Currently this will repeatedly try to connect until the specified timeout expires, then it will exit
  - Start with the server running and leave it running
    - This works fine as before
  - Start with the server running, exit the server, then restart the server before the test completes
     - This initially makes requests
     - IMPROVED: Previously this would OOM even if the server restarted - IMPROVED: Currently this will reconnect and continue making requests if the server restarts

## After - Improved Behavior

https://github.com/hatoo/oha/assets/5617868/9a9d66a8-c114-466d-a823-e1bd086de126

## Before - Existing Behavior

https://github.com/hatoo/oha/assets/5617868/5785a1b9-e755-4dfc-9fdf-7039a0c6ec02