### PR TITLE
Lookup DNS at beginning and cache it

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -266,6 +266,17 @@ impl Client {
         self.http_version == http::Version::HTTP_2
     }
 
+    /// Perform a DNS lookup to cache it
+    /// This is useful to avoid DNS lookup latency at the first concurrent requests
+    pub async fn pre_lookup(&self) -> Result<(), ClientError> {
+        let mut rng = StdRng::from_entropy();
+        let url = self.url_generator.generate(&mut rng)?;
+
+        // It automatically caches the result
+        self.dns.lookup(&url, &mut rng).await?;
+        Ok(())
+    }
+
     async fn client(
         &self,
         addr: (std::net::IpAddr, u16),


### PR DESCRIPTION
Fix #386 

[hickory-dns](https://github.com/hickory-dns/hickory-dns) does cache results but at the beginning, there is no cache, thus *DNS Lookups == Number of Concurrent Connections* is happening.

This PR makes `oha` perform a lookup DNS at the beginning of a run and makes a cache.

I think this solution is more simpler.

@huntharo 
Does this solve your issue?