### PR TITLE
Count /dev/fd using std

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -180,19 +180,7 @@ impl Monitor {
                 bar_num_req.iter().map(|(a, b)| (a.as_str(), *b)).collect();
 
             #[cfg(unix)]
-            let nofile = match tokio::fs::read_dir("/dev/fd").await {
-                Ok(mut dir) => {
-                    let mut count = 0;
-                    loop {
-                        match dir.next_entry().await {
-                            Ok(Some(_)) => count += 1,
-                            Ok(None) => break Ok(count),
-                            Err(err) => break Err(err),
-                        }
-                    }
-                }
-                Err(e) => Err(e),
-            };
+            let nofile = std::fs::read_dir("/dev/fd").map(|dir| dir.count());
 
             terminal.draw(|f| {
                 let row4 = Layout::default()


### PR DESCRIPTION
Possibly fix #384

I could run
```
❯ for x in $(seq 100) do
cargo run --release -- -z 1s -c 400 http://localhost:1337
```

It likely fix but not 100% sure.

But this patch seems good even if it's not fix the issue. I'll merge after CI.