### PR TITLE
fix(417): Make vsock-addr and unix-socket conflict

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -166,13 +166,15 @@ Note: If qps is specified, burst will be ignored",
     #[cfg(unix)]
     #[clap(
         help = "Connect to a unix socket instead of the domain in the URL. Only for non-HTTPS URLs.",
-        long = "unix-socket"
+        long = "unix-socket",
+        group = "socket-type"
     )]
     unix_socket: Option<std::path::PathBuf>,
     #[cfg(feature = "vsock")]
     #[clap(
         help = "Connect to a VSOCK socket using 'cid:port' instead of the domain in the URL. Only for non-HTTPS URLs.",
-        long = "vsock-addr"
+        long = "vsock-addr",
+        group = "socket-type"
     )]
     vsock_addr: Option<VsockAddr>,
     #[clap(


### PR DESCRIPTION
Providing both `--vsock-addr` and `--unix-socket` now throws an error:

```console
$ oha --vsock-addr '1:3000' --unix-socket ./socket 'http://localhost:3000'`
error: the argument '--vsock-addr <VSOCK_ADDR>' cannot be used with '--unix-socket <UNIX_SOCKET>'

Usage: oha [FLAGS] [OPTIONS] <url>

For more information, try '--help'.
```

Closes #417
