### PR TITLE
Fix printing of Size/request

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -396,15 +396,13 @@ fn print_summary<W: Write>(
         "  Total data:\t{:.2}",
         Byte::from_u64(calculate_total_data(res)).get_appropriate_unit(byte_unit::UnitType::Binary)
     )?;
-    writeln!(
-        w,
-        "  Size/request:\t{:.2}",
-        (calculate_size_per_request(res))
-            .map(|n| Byte::from_u64(n)
-                .get_appropriate_unit(byte_unit::UnitType::Binary)
-                .to_string())
-            .unwrap_or_else(|| "NaN".to_string())
-    )?;
+    if let Some(size) = calculate_size_per_request(res)
+        .map(|n| Byte::from_u64(n).get_appropriate_unit(byte_unit::UnitType::Binary))
+    {
+        writeln!(w, "  Size/request:\t{size:.2}")?;
+    } else {
+        writeln!(w, "  Size/request:\tNaN")?;
+    }
     writeln!(
         w,
         "  Size/sec:\t{:.2}",


### PR DESCRIPTION
Previously we formatted the calculated value to a string and then accidentally truncated it to only two characters long in an attempt to support printing NaN in case calculating the value failed.


<details>
<summary>Before</summary>

```
Summary:
…

  Total data:	22.32 MiB
  Size/request:	2.
  Size/sec:	2.23 MiB
```
</details>

<details>
<summary>After</summary>

```
Summary:
…

  Total data:	22.36 MiB
  Size/request:	2.70 KiB
  Size/sec:	2.23 MiB
```
</details>