### PR TITLE
enable http2 adaptive window

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -257,7 +257,8 @@ impl Stream {
         }
     }
     async fn handshake_http2(self) -> Result<SendRequestHttp2, ClientError> {
-        let builder = hyper::client::conn::http2::Builder::new(TokioExecutor::new());
+        let mut builder = hyper::client::conn::http2::Builder::new(TokioExecutor::new());
+        builder.adaptive_window(true);
 
         match self {
             Stream::Tcp(stream) => {


### PR DESCRIPTION
It looks effective to #538 

```bash
$ time ./oha  -c 1 -p 1 -n 100 --http2 https://media2.giphy.com/media/pE4zqXvpwpaUh67tkw/giphy.gif                                                                                                                                                                                                                                                          
Summary:
  Success rate: 100.00%
  Total:        15.4977 secs
  Slowest:      1.1526 secs
  Fastest:      0.1366 secs
  Average:      0.1516 secs
  Requests/sec: 6.4526

  Total data:   245.23 MiB
  Size/request: 2.45 MiB
  Size/sec:     15.82 MiB

Response time histogram:
  0.137 [1]  |
  0.238 [97] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.340 [1]  |
  0.441 [0]  |
  0.543 [0]  |
  0.645 [0]  |
  0.746 [0]  |
  0.848 [0]  |
  0.949 [0]  |
  1.051 [0]  |
  1.153 [1]  |

Response time distribution:
  10.00% in 0.1368 secs
  25.00% in 0.1369 secs
  50.00% in 0.1372 secs
  75.00% in 0.1380 secs
  90.00% in 0.1428 secs
  95.00% in 0.1459 secs
  99.00% in 1.1526 secs
  99.90% in 1.1526 secs
  99.99% in 1.1526 secs


Details (average, fastest, slowest):
  DNS+dialup:   0.0000 secs, 0.0000 secs, 0.0000 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs

Status code distribution:
  [200] 100 responses

real    0m15.528s
user    0m0.976s
sys     0m0.263s
```