### PR TITLE
use svenstaro/upload-release-action@v2

### DIFF
--- a/.github/workflows/release-pgo.yml
+++ b/.github/workflows/release-pgo.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: oven-sh/setup-bun@v1
       - run: bun run pgo.js --target ${{ matrix.target }} ${{ matrix.additional_args }}
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/${{ matrix.target }}/pgo/${{ matrix.artifact_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           args: --release --target ${{ matrix.target }} --locked --no-default-features --features rustls ${{ matrix.additional_args }}
           strip: true
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}


### PR DESCRIPTION
Publish CI fails many time
https://github.com/hatoo/oha/actions/runs/10430465001

Using newer version may fix

See https://github.com/svenstaro/upload-release-action/issues/57