### PR TITLE
chore: Update jsonschema to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,15 +1631,14 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0afd06142c9bcb03f4a8787c77897a87b6be9c4918f1946c33caa714c27578"
+checksum = "f2eef4e82b548e08ac880d307c8e8838b45f497a08d3202f3b26c9debaed8058"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
  "base64",
  "bytecount",
- "clap",
  "fancy-regex",
  "fraction",
  "getrandom",
@@ -1656,7 +1655,7 @@ dependencies = [
  "serde_json",
  "time",
  "url",
- "uuid",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -2090,6 +2089,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
 name = "parking_lot"
@@ -3265,6 +3270,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3291,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vsock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ assert_cmd = "2.0.14"
 axum = { version = "0.7", features = ["http2"] }
 bytes = "1.6"
 float-cmp = "0.9.0"
-jsonschema = "0.18.0"
+jsonschema = "0.20.0"
 lazy_static = "1.5.0"
 predicates = "3.1.0"
 regex = "1.10.5"

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -723,7 +723,7 @@ async fn test_json_schema() {
 
     const SCHEMA: &str = include_str!("../schema.json");
     let schema_value: serde_json::Value = serde_json::from_str(SCHEMA).unwrap();
-    let schema = jsonschema::JSONSchema::compile(&schema_value).unwrap();
+    let validator = jsonschema::validator_for(&schema_value).unwrap();
 
     let output_json: String = String::from_utf8(
         tokio::task::spawn_blocking(move || {
@@ -761,14 +761,14 @@ async fn test_json_schema() {
     let value_stats_success_breakdown: serde_json::Value =
         serde_json::from_str(&output_json_stats_success_breakdown).unwrap();
 
-    if let Err(errors) = schema.validate(&value) {
+    if let Err(errors) = validator.validate(&value) {
         for error in errors {
             eprintln!("{error}");
         }
         panic!("JSON schema validation failed\n{output_json}");
     }
 
-    if let Err(errors) = schema.validate(&value_stats_success_breakdown) {
+    if let Err(errors) = validator.validate(&value_stats_success_breakdown) {
         for error in errors {
             eprintln!("{error}");
         }


### PR DESCRIPTION
Hi!

I've been updating the public API in `jsonschema` and I am here to update the version & add usage of the new API instead of the deprecated one. 