### PR TITLE
docs(install): add x-cmd method to install oha

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ And the binary will be available at `target/[target-triple]/pgo/oha`.
 You can install with [x-cmd](https://www.x-cmd.com).
 
 ```sh
-x env use procs
+x env use oha
 ```
 
 # Platform

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ You can enable VSOCK support by enabling `vsock` feature.
     apt update
     apt install oha
 
+## X-CMD (Linux, macOS, Windows WSL/GitBash)
+
+You can install with [x-cmd](https://www.x-cmd.com).
+
+```sh
+x env use oha
+```
+
 ## Containerized
 
 You can also build and create a container image including oha
@@ -70,14 +78,6 @@ bun run pgo.js
 ```
 
 And the binary will be available at `target/[target-triple]/pgo/oha`.
-
-## X-CMD
-
-You can install with [x-cmd](https://www.x-cmd.com).
-
-```sh
-x env use oha
-```
 
 # Platform
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ bun run pgo.js
 
 And the binary will be available at `target/[target-triple]/pgo/oha`.
 
+## X-CMD
+
+You can install with [x-cmd](https://www.x-cmd.com).
+
+```sh
+x env use procs
+```
+
 # Platform
 
 - Linux - Tested on Ubuntu 18.04 gnome-terminal


### PR DESCRIPTION
Adding a new installation method to the README.
from [issue](https://github.com/hatoo/oha/issues/601).