### PR TITLE
Write URL of the succeed requests to the sqlite database.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -30,6 +30,8 @@ pub struct ConnectionTime {
 #[derive(Debug, Clone)]
 /// a result for a request
 pub struct RequestResult {
+    // Request URL
+    pub url: String,
     // When the query should started
     pub start_latency_correction: Option<std::time::Instant>,
     /// When the query started
@@ -523,6 +525,7 @@ impl Client {
                     let end = std::time::Instant::now();
 
                     let result = RequestResult {
+                        url: url.to_string(),
                         start_latency_correction: None,
                         start,
                         end,
@@ -591,6 +594,7 @@ impl Client {
                     let end = std::time::Instant::now();
 
                     let result = RequestResult {
+                        url: url.to_string(),
                         start_latency_correction: None,
                         start,
                         end,

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,7 @@ use crate::client::RequestResult;
 fn create_db(conn: &Connection) -> Result<usize, rusqlite::Error> {
     conn.execute(
         "CREATE TABLE oha (
+            url TEXT NOT NULL,
             start REAL NOT NULL,
             start_latency_correction REAL,
             end REAL NOT NULL,
@@ -29,8 +30,9 @@ pub fn store(
 
     for request in request_records {
         affected_rows += t.execute(
-            "INSERT INTO oha (start, start_latency_correction, end, duration, status, len_bytes) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO oha (url, start, start_latency_correction, end, duration, status, len_bytes) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             (
+                &request.url.to_string(),
                 (request.start - start).as_secs_f64(),
                 request.start_latency_correction.map(|d| (d - start).as_secs_f64()),
                 (request.end - start).as_secs_f64(),
@@ -54,6 +56,7 @@ mod test_db {
     fn test_store() {
         let start = std::time::Instant::now();
         let test_val = RequestResult {
+            url: "http://example.com".to_string(),
             status: hyper::StatusCode::OK,
             len_bytes: 100,
             start_latency_correction: None,

--- a/src/result_data.rs
+++ b/src/result_data.rs
@@ -193,6 +193,7 @@ mod tests {
     ) -> Result<RequestResult, ClientError> {
         let now = Instant::now();
         Ok(RequestResult {
+            url: "http://example.com".to_string(),
             start_latency_correction: None,
             start: now,
             connection_time: Some(ConnectionTime {


### PR DESCRIPTION
Thanks for oha! It's the perfect tool for the job.

This PR writes the URL (of successful requests) to the sqlite database. I'm using `--rand-regex-url` to make requests with a random correlation id that is propagated through the app and having the url in the sqlite db makes end to end tracing easy.

Suggestions on how to improve my rust are welcome.