### PR TITLE
Convert latency thresholds from magic numbers to named constants

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -57,10 +57,13 @@ impl StyleScheme {
     }
 
     fn latency_distribution(self, text: &str, label: f64) -> StyledContent<&str> {
+        const LATENCY_YELLOW_THRESHOLD: f64 = 0.3;
+        const LATENCY_RED_THRESHOLD: f64 = 0.8;
+
         if self.color_enabled {
-            if label <= 0.3 {
+            if label <= LATENCY_YELLOW_THRESHOLD {
                 text.green()
-            } else if label <= 0.8 {
+            } else if label <= LATENCY_RED_THRESHOLD {
                 text.yellow()
             } else {
                 text.red()


### PR DESCRIPTION
No functional change, just minor code cleanup. Not sure whether it would be better to name these `YELLOW`/`RED` or `GREEN`/`YELLOW`, or `GREEN_YELLOW`/`YELLOW_RED`.

The thing is I was setting up similar thresholds in my grafana, and got curious which these are in oha which I often use, but I've had to spend a few minutes to find them, which wouldn't have been the case if these were named constants.

Out of curiosity, what are your thresholds based on? For now I've only been able to find justification for [400ms threshold](https://lawsofux.com/doherty-threshold/), and I'd probably set this as red, while yellow would be some lower value known to be unnoticeable to user, maybe around 50ms.