### PR TITLE
Avoid tx.send() blocking on work_until_with_qps

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1401,7 +1401,7 @@ pub async fn work_until_with_qps(
 ) {
     let rx = match query_limit {
         QueryLimit::Qps(qps) => {
-            let (tx, rx) = flume::bounded(qps);
+            let (tx, rx) = flume::unbounded();
             tokio::spawn(async move {
                 for i in 0.. {
                     if std::time::Instant::now() > dead_line {


### PR DESCRIPTION
I made it unbounded, because bounded channel donsn't make things better any sense

fixed #603