### PR TITLE
Use number of physical cores workers because it's more performant empirically.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hickory-proto"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2283,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2329,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "native-tls",
+ "num_cpus",
  "pin-project-lite",
  "predicates",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ http-body-util = "0.1.2"
 hyper-util = { version = "0.1.6", features = ["tokio"] }
 tokio-vsock = { version = "0.5.0", optional = true }
 rusqlite = { version = "0.32.0", features = ["bundled"] }
+num_cpus = "1.16.0"
 
 [target.'cfg(unix)'.dependencies]
 rlimit = "0.10.1"


### PR DESCRIPTION
I've observed that using the number of *physical* cores is more performant in `oha` in hyper-threading environment.

note: https://github.com/tokio-rs/tokio/pull/2391