### PR TITLE
chore(deps): chore(deps): bump `cc` crate to 1.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.8"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "jobserver",
  "libc",


### PR DESCRIPTION
seeing some homebrew build issue as 

```
    cargo:warning=ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET LC_ALL="C" "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "--target=arm64-apple-macosx15.2" "-std=c99" "-I" "/Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.24.1/generated-include" "-I" "/Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.24.1/include" "-I" "/Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.24.1/aws-lc/include" "-I" "/Users/brew/Library/Caches/Homebrew/cargo_cache/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.24.1/aws-lc/third_party/s2n-bignum/include" "-Wall" "-Wextra" "-Wno-unused-parameter" "-DBORINGSSL_IMPLEMENTATION=1" "-DBORINGSSL_PREFIX=aws_lc_0_24_1" "-o" "/private/tmp/oha-20250111-7637-er8fq1/oha-1.6.0/target/release/build/aws-lc-sys-207927fd5e1d0882/out/b6b55cf018b1a41e-bignum_sub_p384.o" "-c" "--" "/private/tmp/oha-20250111-7637-er8fq1/oha-1.6.0/target/release/build/aws-lc-sys-207927fd5e1d0882/out/third_party/s2n-bignum/arm/p384/bignum_sub_p384.S" with args clang did not execute successfully (status code exit status: 1).cargo:warning=clang: error: no such file or directory: '-isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk'
```

relates to:
- https://github.com/Homebrew/homebrew-core/pull/203929
- https://github.com/rust-lang/cc-rs/issues/1362