### PR TITLE
fix: improve error handling for URLs without scheme

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -857,7 +857,7 @@ fn main() {
 
     if let Err(e) = rt.block_on(run()) {
         eprintln!("Error: {}", e);
-        std::process::exit(1);
+        std::process::exit(libc::EXIT_FAILURE);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -854,7 +854,11 @@ fn main() {
         .enable_all()
         .build()
         .unwrap();
-    rt.block_on(run()).unwrap();
+
+    if let Err(e) = rt.block_on(run()) {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
 }
 
 enum WorkMode {


### PR DESCRIPTION
While using oha, I found that it panics when given a URL without a scheme (e.g., localhost:4221 instead of http://localhost:4221). 

Instead of a friendly error message, we get this panic:
![image](https://github.com/user-attachments/assets/b90cf719-0a81-413f-8157-3e5d71aba676)

## Proposed Change
I tried to make this a bit more user-friendly by:
- Replace unwrap() with some error handling
- Set exit code on failure

> I'm new to the project, so please let me know if there's a better way to handle this.