### PR TITLE
Randomize --connect-to if multiple matching options

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Options:
           Accept invalid certs.
       --connect-to <CONNECT_TO>
           Override DNS resolution and default port numbers with strings like 'example.org:443:localhost:8443'
+          Note: if used several times for the same host:port:target_host:target_port, a random choice is made
       --disable-color
           Disable the color scheme.
       --unix-socket <UNIX_SOCKET>

--- a/src/client.rs
+++ b/src/client.rs
@@ -79,11 +79,14 @@ impl Dns {
             .port_or_known_default()
             .ok_or(ClientError::PortNotFound)?;
 
-        // Try to find an override (passed via `--connect-to`) that applies to this (host, port)
+        // Try to find an override (passed via `--connect-to`) that applies to this (host, port),
+        // choosing one randomly if several match.
         let (host, port) = if let Some(entry) = self
             .connect_to
             .iter()
-            .find(|entry| entry.requested_port == port && entry.requested_host == host)
+            .filter(|entry| entry.requested_port == port && entry.requested_host == host)
+            .collect::<Vec<_>>()
+            .choose(rng)
         {
             (entry.target_host.as_str(), entry.target_port)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,8 @@ Note: If qps is specified, burst will be ignored",
     #[arg(help = "Accept invalid certs.", long = "insecure")]
     insecure: bool,
     #[arg(
-        help = "Override DNS resolution and default port numbers with strings like 'example.org:443:localhost:8443'",
+        help = "Override DNS resolution and default port numbers with strings like 'example.org:443:localhost:8443'
+Note: if used several times for the same host:port:target_host:target_port, a random choice is made",
         long = "connect-to"
     )]
     connect_to: Vec<ConnectToEntry>,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -319,7 +319,7 @@ async fn distribution_on_two_matching_connect_to(host: &'static str) -> (i32, i3
         "/",
         get(move || async move {
             tx2.send(()).unwrap();
-            "Success1"
+            "Success2"
         }),
     );
 
@@ -347,9 +347,9 @@ async fn distribution_on_two_matching_connect_to(host: &'static str) -> (i32, i3
     let mut count1 = 0;
     let mut count2 = 0;
     loop {
-        if let Ok(_) = rx1.try_recv() {
+        if rx1.try_recv().is_ok() {
             count1 += 1;
-        } else if let Ok(_) = rx2.try_recv() {
+        } else if rx2.try_recv().is_ok() {
             count2 += 1;
         } else {
             break;


### PR DESCRIPTION
Here is a PR to better handle this:
```
oha \
  --connect-to something.com:443:backend1.fqdn:8443 \
  --connect-to something.com:443:backend2.fqdn:8443 \
  https://something.com
```
In this case, a random choice will be made for each request between `backend1.fqdn:8443` and `backend2.fqdn:8443`.  Where as currently, while the syntax is not rejected, it's always the same target which would be picked.

My use case is being able to bypass an actual TCP load-balancer in front of the backend servers, just to check it doesn't have a significant impact on the overall performances.

I've seen that DNS resolution already makes some similar random choice per-request in case several IP are returned for the domain. I guess I could use that (with some local dnsmasq entries) for my use case, but this `--connect-to` approach sounds more intuitive.

The second commit is a test case with 100 requests to spread across two servers, listening on two local ports. It checks that both receive at least some requests, and that the total number of requests received is indeed 100.