### PR TITLE
Add support for results in csv format

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ Options:
           Correct latency to avoid coordinated omission problem. It's ignored if -q is not set.
       --no-tui
           No realtime tui
-  -j, --json
-          Print results as JSON
       --fps <FPS>
           Frame per second for tui. [default: 16]
   -m, --method <METHOD>
@@ -208,6 +206,8 @@ Options:
           Perform a single request and dump the request and response
   -o, --output <OUTPUT>
           Output file to write the results to. If not specified, results are written to stdout.
+      --output-format <OUTPUT_FORMAT>
+          Output format, either 'text', 'json' or 'csv'. [default 'text']
   -h, --help
           Print help
   -V, --version
@@ -218,10 +218,14 @@ Options:
 
 `oha` uses faster implementation when `--no-tui` option is set and both `-q` and `--burst-delay` are not set because it can avoid overhead to gather data realtime.
 
-# JSON output
+# Output
 
-`oha` prints JSON output when `-j` option is set.
+By default `oha` outputs a text summary of the results.
+
+`oha` prints JSON summary output when `--output-format json` option is set.
 The schema of JSON output is defined in [schema.json](./schema.json).
+
+When `--output-format csv` is used result of each request is printed as a line of comma separated values.
 
 # Tips
 

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "description": "JSON schema for the output of the `oha -j`",
+    "description": "JSON schema for the output of the `oha --output-format json`",
     "type": "object",
     "properties": {
         "summary": {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,6 @@ Note: If qps is specified, burst will be ignored",
     latency_correction: bool,
     #[arg(help = "No realtime tui", long = "no-tui")]
     no_tui: bool,
-    #[arg(help = "Print results as JSON", short, long)]
-    json: bool,
     #[arg(help = "Frame per second for tui.", default_value = "16", long = "fps")]
     fps: usize,
     #[arg(
@@ -278,6 +276,8 @@ Note: if used several times for the same host:port:target_host:target_port, a ra
         short
     )]
     output: Option<PathBuf>,
+    #[arg(help = "Output format", long, default_value = "text")]
+    output_format: Option<PrintMode>,
 }
 
 /// An entry specified by `connect-to` to override DNS resolution and default
@@ -598,11 +598,7 @@ pub async fn run(mut opts: Opts) -> anyhow::Result<()> {
     let no_tui = opts.no_tui || !std::io::stdout().is_tty() || opts.debug;
 
     let print_config = {
-        let mode = if opts.json {
-            PrintMode::Json
-        } else {
-            PrintMode::Text
-        };
+        let mode = opts.output_format.unwrap_or_default();
 
         let disable_style =
             opts.disable_color || !std::io::stdout().is_tty() || opts.output.is_some();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -590,7 +590,7 @@ async fn test_query() {
             .uri()
             .to_string()
             .split('/')
-            .last()
+            .next_back()
             .unwrap(),
         "index?a=b&c=d".to_string()
     );
@@ -615,7 +615,7 @@ async fn test_query_rand_regex() {
         .uri()
         .to_string()
         .split('/')
-        .last()
+        .next_back()
         .unwrap()
         .chars()
         .collect::<Vec<char>>();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,6 +5,7 @@ use std::{
     future::Future,
     io::Write,
     net::{Ipv6Addr, SocketAddr},
+    str::FromStr,
     sync::{Arc, atomic::AtomicU16},
 };
 
@@ -928,7 +929,7 @@ async fn test_json_schema() {
         tokio::task::spawn_blocking(move || {
             Command::cargo_bin("oha")
                 .unwrap()
-                .args(["-n", "10", "--no-tui", "-j"])
+                .args(["-n", "10", "--no-tui", "--output-format", "json"])
                 .arg(format!("http://127.0.0.1:{port}/"))
                 .assert()
                 .get_output()
@@ -944,7 +945,14 @@ async fn test_json_schema() {
         tokio::task::spawn_blocking(move || {
             Command::cargo_bin("oha")
                 .unwrap()
-                .args(["-n", "10", "--no-tui", "-j", "--stats-success-breakdown"])
+                .args([
+                    "-n",
+                    "10",
+                    "--no-tui",
+                    "--output-format",
+                    "json",
+                    "--stats-success-breakdown",
+                ])
                 .arg(format!("http://127.0.0.1:{port}/"))
                 .assert()
                 .get_output()
@@ -972,6 +980,58 @@ async fn test_json_schema() {
             eprintln!("{error}");
         }
         panic!("JSON schema validation failed\n{output_json_stats_success_breakdown}");
+    }
+}
+
+#[tokio::test]
+async fn test_csv_output() {
+    let app = Router::new().route("/", get(|| async move { "Hello World" }));
+
+    let (listener, port) = bind_port().await;
+    tokio::spawn(async { axum::serve(listener, app).await });
+
+    let output_csv: String = String::from_utf8(
+        tokio::task::spawn_blocking(move || {
+            Command::cargo_bin("oha")
+                .unwrap()
+                .args(["-n", "5", "--no-tui", "--output-format", "csv"])
+                .arg(format!("http://127.0.0.1:{port}/"))
+                .assert()
+                .get_output()
+                .stdout
+                .clone()
+        })
+        .await
+        .unwrap(),
+    )
+    .unwrap();
+
+    // Validate that we get CSV output in following format,
+    // header and one row for each request:
+    // request-start,DNS,DNS+dialup,request-duration,bytes,status
+    // 0.002219628,0.000309806,0.001021632,0.002023073,11,200
+    // ...
+
+    let lines: Vec<&str> = output_csv.lines().collect();
+    assert_eq!(lines.len(), 6);
+    assert_eq!(
+        lines[0],
+        "request-start,DNS,DNS+dialup,request-duration,bytes,status"
+    );
+    let mut latest_start = 0f64;
+    for line in lines.iter().skip(1) {
+        let parts: Vec<&str> = line.split(",").collect();
+        assert_eq!(parts.len(), 6);
+        // validate that the requests are in ascending time order
+        let current_start = f64::from_str(parts[0]).unwrap();
+        println!("current: {current_start}");
+        assert!(current_start >= latest_start);
+        latest_start = current_start;
+        assert!(f64::from_str(parts[1]).unwrap() > 0f64);
+        assert!(f64::from_str(parts[2]).unwrap() > 0f64);
+        assert!(f64::from_str(parts[3]).unwrap() > 0f64);
+        assert_eq!(usize::from_str(parts[4]).unwrap(), 11);
+        assert_eq!(u16::from_str(parts[5]).unwrap(), 200);
     }
 }
 


### PR DESCRIPTION
This adds support for outputting the result of each request as CSV line. This is similar as in the `-o` option in `hey` load generator though the CSV format here is different.

There is also a new `--output-format` command line switch which can take values `text` (default), `json` or `csv`. Previous `-j` / `--json` flag has been removed to consolidate output selection to use the one `--output-format` flag. This seemed like a better way to handle multiple output formats instead of adding separate (exclusive) flags for each different output format, but open to suggestions on this if there's a better way to organize the flags, also open to suggestions on the CSV format.