### PR TITLE
Refactor to enhance code re-use and prepare for HTTP/3 support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use http_body_util::{BodyExt, Full};
 use hyper::{Method, http};
 use hyper_util::rt::{TokioExecutor, TokioIo};
+use kanal::AsyncReceiver;
 use rand::prelude::*;
 use std::{
     borrow::Cow,
@@ -61,6 +62,13 @@ impl RequestResult {
     pub fn duration(&self) -> std::time::Duration {
         self.end - self.start_latency_correction.unwrap_or(self.start)
     }
+}
+
+// encapsulates the HTTP generation of the work type. Used internally only for conditional logic.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum HttpWorkType {
+    H1,
+    H2,
 }
 
 pub struct Dns {
@@ -255,7 +263,7 @@ pub enum QueryLimit {
 
 // To avoid dynamic dispatch
 // I'm not sure how much this is effective
-enum Stream {
+pub(crate) enum Stream {
     Tcp(TcpStream),
     #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     Tls(tokio_native_tls::TlsStream<TcpStream>),
@@ -356,6 +364,11 @@ impl Client {
     }
 
     #[inline]
+    pub fn is_http1(&self) -> bool {
+        self.http_version <= http::Version::HTTP_11
+    }
+
+    #[inline]
     fn is_proxy_http2(&self) -> bool {
         self.proxy_http_version == http::Version::HTTP_2
     }
@@ -373,6 +386,15 @@ impl Client {
             }
         } else {
             self.is_http2()
+        }
+    }
+
+    // slightly naughty reusing the HTTP version (there are different versions of 1)
+    fn work_type(&self) -> HttpWorkType {
+        if self.is_work_http2() {
+            HttpWorkType::H2
+        } else {
+            HttpWorkType::H1
         }
     }
 
@@ -403,11 +425,14 @@ impl Client {
         Ok((self.url_generator.generate(rng)?, snapshot))
     }
 
-    async fn client<R: Rng>(
+    /**
+     * Returns a stream of the underlying transport. NOT a HTTP client
+     */
+    pub(crate) async fn client<R: Rng>(
         &self,
         url: &Url,
         rng: &mut R,
-        is_http2: bool,
+        http_version: http::Version,
     ) -> Result<(Instant, Stream), ClientError> {
         // TODO: Allow the connect timeout to be configured
         let timeout_duration = tokio::time::Duration::from_secs(5);
@@ -418,7 +443,8 @@ impl Client {
             // If we do not put a timeout here then the connections attempts will
             // linger long past the configured timeout
             let stream =
-                tokio::time::timeout(timeout_duration, self.tls_client(addr, url, is_http2)).await;
+                tokio::time::timeout(timeout_duration, self.tls_client(addr, url, http_version))
+                    .await;
             return match stream {
                 Ok(Ok(stream)) => Ok((dns_lookup, stream)),
                 Ok(Err(err)) => Err(err),
@@ -470,12 +496,12 @@ impl Client {
         &self,
         addr: (std::net::IpAddr, u16),
         url: &Url,
-        is_http2: bool,
+        http_version: http::Version,
     ) -> Result<Stream, ClientError> {
         let stream = tokio::net::TcpStream::connect(addr).await?;
         stream.set_nodelay(true)?;
 
-        let stream = self.connect_tls(stream, url, is_http2).await?;
+        let stream = self.connect_tls(stream, url, http_version).await?;
 
         Ok(Stream::Tls(stream))
     }
@@ -485,12 +511,14 @@ impl Client {
         &self,
         stream: S,
         url: &Url,
-        is_http2: bool,
+        http_version: http::Version,
     ) -> Result<tokio_native_tls::TlsStream<S>, ClientError>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        let connector = self.native_tls_connectors.connector(is_http2);
+        let connector = self
+            .native_tls_connectors
+            .connector(http_version >= http::Version::HTTP_2);
         let stream = connector
             .connect(url.host_str().ok_or(ClientError::HostNotFound)?, stream)
             .await?;
@@ -503,13 +531,13 @@ impl Client {
         &self,
         stream: S,
         url: &Url,
-        is_http2: bool,
+        http_version: http::Version,
     ) -> Result<Box<tokio_rustls::client::TlsStream<S>>, ClientError>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
         let connector =
-            tokio_rustls::TlsConnector::from(self.rustls_configs.config(is_http2).clone());
+            tokio_rustls::TlsConnector::from(self.rustls_configs.config(http_version).clone());
         let domain = rustls_pki_types::ServerName::try_from(
             url.host_str().ok_or(ClientError::HostNotFound)?,
         )?;
@@ -524,7 +552,12 @@ impl Client {
         rng: &mut R,
     ) -> Result<(Instant, SendRequestHttp1), ClientError> {
         if let Some(proxy_url) = &self.proxy_url {
-            let (dns_lookup, stream) = self.client(proxy_url, rng, self.is_proxy_http2()).await?;
+            let http_proxy_version = if self.is_proxy_http2() {
+                http::Version::HTTP_2
+            } else {
+                http::Version::HTTP_11
+            };
+            let (dns_lookup, stream) = self.client(proxy_url, rng, http_proxy_version).await?;
             if url.scheme() == "https" {
                 // Do CONNECT request to proxy
                 let req = {
@@ -550,7 +583,9 @@ impl Client {
                     send_request.send_request(req).await?
                 };
                 let stream = hyper::upgrade::on(res).await?;
-                let stream = self.connect_tls(TokioIo::new(stream), url, false).await?;
+                let stream = self
+                    .connect_tls(TokioIo::new(stream), url, self.http_version)
+                    .await?;
                 let (send_request, conn) =
                     hyper::client::conn::http1::handshake(TokioIo::new(stream)).await?;
                 tokio::spawn(conn);
@@ -560,17 +595,17 @@ impl Client {
                 Ok((dns_lookup, stream.handshake_http1(false).await?))
             }
         } else {
-            let (dns_lookup, stream) = self.client(url, rng, false).await?;
+            let (dns_lookup, stream) = self.client(url, rng, http::Version::HTTP_11).await?;
             Ok((dns_lookup, stream.handshake_http1(false).await?))
         }
     }
 
     #[inline]
-    fn request(&self, url: &Url) -> Result<http::Request<Full<Bytes>>, ClientError> {
+    pub(crate) fn request(&self, url: &Url) -> Result<http::Request<Full<Bytes>>, ClientError> {
         let use_proxy = self.proxy_url.is_some() && url.scheme() == "http";
 
         let mut builder = http::Request::builder()
-            .uri(if self.is_http2() || use_proxy {
+            .uri(if !(self.is_http1()) || use_proxy {
                 &url[..]
             } else {
                 &url[url::Position::BeforePath..]
@@ -713,13 +748,19 @@ impl Client {
             do_req.await
         }
     }
+
     async fn connect_http2<R: Rng>(
         &self,
         url: &Url,
         rng: &mut R,
     ) -> Result<(ConnectionTime, SendRequestHttp2), ClientError> {
         if let Some(proxy_url) = &self.proxy_url {
-            let (dns_lookup, stream) = self.client(proxy_url, rng, self.is_proxy_http2()).await?;
+            let http_proxy_version = if self.is_proxy_http2() {
+                http::Version::HTTP_2
+            } else {
+                http::Version::HTTP_11
+            };
+            let (dns_lookup, stream) = self.client(proxy_url, rng, http_proxy_version).await?;
             if url.scheme() == "https" {
                 let req = {
                     let mut builder =
@@ -744,7 +785,9 @@ impl Client {
                     send_request.send_request(req).await?
                 };
                 let stream = hyper::upgrade::on(res).await?;
-                let stream = self.connect_tls(TokioIo::new(stream), url, true).await?;
+                let stream = self
+                    .connect_tls(TokioIo::new(stream), url, http::Version::HTTP_2)
+                    .await?;
                 let (send_request, conn) =
                     hyper::client::conn::http2::Builder::new(TokioExecutor::new())
                         // from nghttp2's default
@@ -762,7 +805,7 @@ impl Client {
                 Ok((ConnectionTime { dns_lookup, dialup }, send_request))
             }
         } else {
-            let (dns_lookup, stream) = self.client(url, rng, true).await?;
+            let (dns_lookup, stream) = self.client(url, rng, self.http_version).await?;
             let send_request = stream.handshake_http2().await?;
             let dialup = std::time::Instant::now();
             Ok((ConnectionTime { dns_lookup, dialup }, send_request))
@@ -973,18 +1016,19 @@ pub async fn work_debug<W: Write>(w: &mut W, client: Arc<Client>) -> Result<(), 
 
     writeln!(w, "{:#?}", request)?;
 
-    let response = if client.is_work_http2() {
-        let (_, mut client_state) = client.connect_http2(&url, &mut rng).await?;
-        client_state.send_request(request).await?
-    } else {
-        let (_dns_lookup, mut send_request) = client.client_http1(&url, &mut rng).await?;
-
-        send_request.send_request(request).await?
+    let response = match client.work_type() {
+        HttpWorkType::H2 => {
+            let (_, mut client_state) = client.connect_http2(&url, &mut rng).await?;
+            client_state.send_request(request).await?
+        }
+        HttpWorkType::H1 => {
+            let (_dns_lookup, mut send_request) = client.client_http1(&url, &mut rng).await?;
+            send_request.send_request(request).await?
+        }
     };
 
     let (parts, body) = response.into_parts();
     let body = body.collect().await.unwrap().to_bytes();
-
     let response = http::Response::from_parts(parts, body);
 
     writeln!(w, "{:#?}", response)?;
@@ -1000,108 +1044,27 @@ pub async fn work(
     n_connections: usize,
     n_http2_parallel: usize,
 ) {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    let counter = Arc::new(AtomicUsize::new(0));
+    let (tx, rx) = kanal::unbounded::<Option<Instant>>();
+    let rx = rx.to_async();
 
-    if client.is_work_http2() {
-        let futures = (0..n_connections)
-            .map(|_| {
-                let report_tx = report_tx.clone();
-                let counter = counter.clone();
-                let client = client.clone();
-                tokio::spawn(async move {
-                    loop {
-                        match setup_http2(&client).await {
-                            Ok((connection_time, send_request)) => {
-                                let futures = (0..n_http2_parallel)
-                                    .map(|_| {
-                                        let report_tx = report_tx.clone();
-                                        let counter = counter.clone();
-                                        let client = client.clone();
-
-                                        let mut client_state = ClientStateHttp2 {
-                                            rng: SeedableRng::from_os_rng(),
-                                            send_request: send_request.clone(),
-                                        };
-                                        tokio::spawn(async move {
-                                            while counter.fetch_add(1, Ordering::Relaxed) < n_tasks
-                                            {
-                                                let (is_cancel, is_reconnect) = work_http2_once(
-                                                    &client,
-                                                    &mut client_state,
-                                                    &report_tx,
-                                                    connection_time,
-                                                    None,
-                                                )
-                                                .await;
-
-                                                if is_cancel || is_reconnect {
-                                                    return is_cancel;
-                                                }
-                                            }
-
-                                            true
-                                        })
-                                    })
-                                    .collect::<Vec<_>>();
-
-                                let mut connection_gone = false;
-                                for f in futures {
-                                    match f.await {
-                                        Ok(true) => {
-                                            // All works done
-                                            connection_gone = true;
-                                        }
-                                        Err(_) => {
-                                            // Unexpected
-                                            connection_gone = true;
-                                        }
-                                        _ => {}
-                                    }
-                                }
-
-                                if connection_gone {
-                                    return;
-                                }
-                            }
-                            Err(err) => {
-                                if counter.fetch_add(1, Ordering::Relaxed) < n_tasks {
-                                    report_tx.send(Err(err)).unwrap();
-                                } else {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-        for f in futures {
-            let _ = f.await;
+    let n_tasks_emitter = async move {
+        for _ in 0..n_tasks {
+            tx.send(None)?
         }
-    } else {
-        let futures = (0..n_connections)
-            .map(|_| {
-                let report_tx = report_tx.clone();
-                let counter = counter.clone();
-                let client = client.clone();
-                tokio::spawn(async move {
-                    let mut client_state = ClientStateHttp1::default();
-                    while counter.fetch_add(1, Ordering::Relaxed) < n_tasks {
-                        let res = client.work_http1(&mut client_state).await;
-                        let is_cancel = is_cancel_error(&res);
-                        report_tx.send(res).unwrap();
-                        if is_cancel {
-                            break;
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-        for f in futures {
-            let _ = f.await;
+        drop(tx);
+        Ok::<(), kanal::SendError>(())
+    };
+
+    let futures = match client.work_type() {
+        HttpWorkType::H1 => parallel_work_http1(n_connections, rx, report_tx, client, None).await,
+        HttpWorkType::H2 => {
+            parallel_work_http2(n_connections, n_http2_parallel, rx, report_tx, client, None).await
         }
     };
+    n_tasks_emitter.await.unwrap();
+    for f in futures {
+        let _ = f.await;
+    }
 }
 
 /// n tasks by m workers limit to qps works in a second
@@ -1124,7 +1087,7 @@ pub async fn work_with_qps(
                         (start + std::time::Duration::from_secs_f64(i as f64 * 1f64 / qps)).into(),
                     )
                     .await;
-                    tx.send(())?;
+                    tx.send(None)?;
                 }
             }
             QueryLimit::Burst(duration, rate) => {
@@ -1133,7 +1096,7 @@ pub async fn work_with_qps(
                 while n + rate < n_tasks {
                     tokio::time::sleep(duration).await;
                     for _ in 0..rate {
-                        tx.send(())?;
+                        tx.send(None)?;
                     }
                     n += rate;
                 }
@@ -1141,7 +1104,7 @@ pub async fn work_with_qps(
                 if n_tasks > n {
                     tokio::time::sleep(duration).await;
                     for _ in 0..n_tasks - n {
-                        tx.send(())?;
+                        tx.send(None)?;
                     }
                 }
             }
@@ -1152,105 +1115,162 @@ pub async fn work_with_qps(
     };
 
     let rx = rx.to_async();
-    if client.is_work_http2() {
-        let futures = (0..n_connections)
-            .map(|_| {
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                let client = client.clone();
-                tokio::spawn(async move {
-                    loop {
-                        match setup_http2(&client).await {
-                            Ok((connection_time, send_request)) => {
-                                let futures = (0..n_http2_parallel)
-                                    .map(|_| {
-                                        let report_tx = report_tx.clone();
-                                        let rx = rx.clone();
-                                        let client = client.clone();
-                                        let mut client_state = ClientStateHttp2 {
-                                            rng: SeedableRng::from_os_rng(),
-                                            send_request: send_request.clone(),
-                                        };
-                                        tokio::spawn(async move {
-                                            while let Ok(()) = rx.recv().await {
-                                                let (is_cancel, is_reconnect) = work_http2_once(
-                                                    &client,
-                                                    &mut client_state,
-                                                    &report_tx,
-                                                    connection_time,
-                                                    None,
-                                                )
-                                                .await;
-
-                                                if is_cancel || is_reconnect {
-                                                    return is_cancel;
-                                                }
-                                            }
-                                            true
-                                        })
-                                    })
-                                    .collect::<Vec<_>>();
-                                let mut connection_gone = false;
-                                for f in futures {
-                                    match f.await {
-                                        Ok(true) => {
-                                            // All works done
-                                            connection_gone = true;
-                                        }
-                                        Err(_) => {
-                                            // Unexpected
-                                            connection_gone = true;
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                                if connection_gone {
-                                    return;
-                                }
-                            }
-                            Err(err) => {
-                                // Consume a task
-                                if let Ok(()) = rx.recv().await {
-                                    report_tx.send(Err(err)).unwrap();
-                                } else {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        work_queue.await.unwrap();
-        for f in futures {
-            let _ = f.await;
-        }
-    } else {
-        let futures = (0..n_connections)
-            .map(|_| {
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                let client = client.clone();
-                tokio::spawn(async move {
-                    let mut client_state = ClientStateHttp1::default();
-                    while let Ok(()) = rx.recv().await {
-                        let res = client.work_http1(&mut client_state).await;
-                        let is_cancel = is_cancel_error(&res);
-                        report_tx.send(res).unwrap();
-                        if is_cancel {
-                            break;
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        work_queue.await.unwrap();
-        for f in futures {
-            let _ = f.await;
+    let futures = match client.work_type() {
+        HttpWorkType::H1 => parallel_work_http1(n_connections, rx, report_tx, client, None).await,
+        HttpWorkType::H2 => {
+            parallel_work_http2(n_connections, n_http2_parallel, rx, report_tx, client, None).await
         }
     };
+    work_queue.await.unwrap();
+    for f in futures {
+        let _ = f.await;
+    }
+}
+
+async fn parallel_work_http1(
+    n_connections: usize,
+    rx: AsyncReceiver<Option<Instant>>,
+    report_tx: kanal::Sender<Result<RequestResult, ClientError>>,
+    client: Arc<Client>,
+    deadline: Option<std::time::Instant>,
+) -> Vec<tokio::task::JoinHandle<()>> {
+    let is_end = Arc::new(AtomicBool::new(false));
+    let has_deadline = deadline.is_some();
+
+    let futures = (0..n_connections)
+        .map(|_| {
+            let report_tx = report_tx.clone();
+            let rx = rx.clone();
+            let client = client.clone();
+            let is_end = is_end.clone();
+            let mut client_state = ClientStateHttp1::default();
+            tokio::spawn(async move {
+                while let Ok(rx_value) = rx.recv().await {
+                    let mut res = client.work_http1(&mut client_state).await;
+                    if let Some(start_latency_correction) = rx_value {
+                        set_start_latency_correction(&mut res, start_latency_correction);
+                    }
+                    let is_cancel = is_cancel_error(&res);
+                    report_tx.send(res).unwrap();
+                    if is_cancel || is_end.load(Relaxed) {
+                        break;
+                    }
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if has_deadline {
+        tokio::time::sleep_until(deadline.unwrap().into()).await;
+        is_end.store(true, Relaxed);
+    };
+
+    futures
+}
+
+async fn parallel_work_http2(
+    n_connections: usize,
+    n_http2_parallel: usize,
+    rx: AsyncReceiver<Option<Instant>>,
+    report_tx: kanal::Sender<Result<RequestResult, ClientError>>,
+    client: Arc<Client>,
+    deadline: Option<std::time::Instant>,
+) -> Vec<tokio::task::JoinHandle<()>> {
+    // Using semaphore to control the deadline
+    // Maybe there is a better concurrent primitive to do this
+    let s = Arc::new(tokio::sync::Semaphore::new(0));
+    let has_deadline = deadline.is_some();
+
+    let futures = (0..n_connections)
+        .map(|_| {
+            let report_tx = report_tx.clone();
+            let rx = rx.clone();
+            let client = client.clone();
+            let s = s.clone();
+            tokio::spawn(async move {
+                let s = s.clone();
+                loop {
+                    match setup_http2(&client).await {
+                        Ok((connection_time, send_request)) => {
+                            let futures = (0..n_http2_parallel)
+                                .map(|_| {
+                                    let report_tx = report_tx.clone();
+                                    let rx = rx.clone();
+                                    let client = client.clone();
+                                    let mut client_state = ClientStateHttp2 {
+                                        rng: SeedableRng::from_os_rng(),
+                                        send_request: send_request.clone(),
+                                    };
+                                    let s = s.clone();
+                                    tokio::spawn(async move {
+                                        // This is where HTTP2 loops to make all the requests for a given client and worker
+                                        while let Ok(start_time_option) = rx.recv().await {
+                                            let (is_cancel, is_reconnect) = work_http2_once(
+                                                &client,
+                                                &mut client_state,
+                                                &report_tx,
+                                                connection_time,
+                                                start_time_option,
+                                            )
+                                            .await;
+
+                                            let is_cancel = is_cancel || s.is_closed();
+                                            if is_cancel || is_reconnect {
+                                                return is_cancel;
+                                            }
+                                        }
+                                        true
+                                    })
+                                })
+                                .collect::<Vec<_>>();
+                            let mut connection_gone = false;
+                            for f in futures {
+                                tokio::select! {
+                                    r = f => {
+                                        match r {
+                                            Ok(true) => {
+                                                // All works done
+                                                connection_gone = true;
+                                            }
+                                            Err(_) => {
+                                                // Unexpected
+                                                connection_gone = true;
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                    _ = s.acquire() => {
+                                        report_tx.send(Err(ClientError::Deadline)).unwrap();
+                                        connection_gone = true;
+                                    }
+                                }
+                            }
+                            if connection_gone {
+                                return;
+                            }
+                        }
+                        Err(err) => {
+                            if s.is_closed() {
+                                break;
+                                // Consume a task
+                            } else if rx.recv().await.is_ok() {
+                                report_tx.send(Err(err)).unwrap();
+                            } else {
+                                return;
+                            }
+                        }
+                    }
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if has_deadline {
+        tokio::time::sleep_until(deadline.unwrap().into()).await;
+        s.close();
+    }
+
+    futures
 }
 
 /// n tasks by m workers limit to qps works in a second with latency correction
@@ -1263,6 +1283,7 @@ pub async fn work_with_qps_latency_correction(
     n_http2_parallel: usize,
 ) {
     let (tx, rx) = kanal::unbounded();
+    let rx = rx.to_async();
 
     let work_queue = async move {
         match query_limit {
@@ -1273,7 +1294,7 @@ pub async fn work_with_qps_latency_correction(
                         (start + std::time::Duration::from_secs_f64(i as f64 * 1f64 / qps)).into(),
                     )
                     .await;
-                    tx.send(std::time::Instant::now())?;
+                    tx.send(Some(std::time::Instant::now()))?;
                 }
             }
             QueryLimit::Burst(duration, rate) => {
@@ -1283,7 +1304,7 @@ pub async fn work_with_qps_latency_correction(
                     tokio::time::sleep(duration).await;
                     let now = std::time::Instant::now();
                     for _ in 0..rate {
-                        tx.send(now)?;
+                        tx.send(Some(now))?;
                     }
                     n += rate;
                 }
@@ -1292,7 +1313,7 @@ pub async fn work_with_qps_latency_correction(
                     tokio::time::sleep(duration).await;
                     let now = std::time::Instant::now();
                     for _ in 0..n_tasks - n {
-                        tx.send(now)?;
+                        tx.send(Some(now))?;
                     }
                 }
             }
@@ -1303,107 +1324,16 @@ pub async fn work_with_qps_latency_correction(
         Ok::<(), kanal::SendError>(())
     };
 
-    let rx = rx.to_async();
-    if client.is_work_http2() {
-        let futures = (0..n_connections)
-            .map(|_| {
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                let client = client.clone();
-                tokio::spawn(async move {
-                    loop {
-                        match setup_http2(&client).await {
-                            Ok((connection_time, send_request)) => {
-                                let futures = (0..n_http2_parallel)
-                                    .map(|_| {
-                                        let report_tx = report_tx.clone();
-                                        let rx = rx.clone();
-                                        let client = client.clone();
-                                        let mut client_state = ClientStateHttp2 {
-                                            rng: SeedableRng::from_os_rng(),
-                                            send_request: send_request.clone(),
-                                        };
-                                        tokio::spawn(async move {
-                                            while let Ok(start) = rx.recv().await {
-                                                let (is_cancel, is_reconnect) = work_http2_once(
-                                                    &client,
-                                                    &mut client_state,
-                                                    &report_tx,
-                                                    connection_time,
-                                                    Some(start),
-                                                )
-                                                .await;
-
-                                                if is_cancel || is_reconnect {
-                                                    return is_cancel;
-                                                }
-                                            }
-                                            true
-                                        })
-                                    })
-                                    .collect::<Vec<_>>();
-                                let mut connection_gone = false;
-                                for f in futures {
-                                    match f.await {
-                                        Ok(true) => {
-                                            // All works done
-                                            connection_gone = true;
-                                        }
-                                        Err(_) => {
-                                            // Unexpected
-                                            connection_gone = true;
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                                if connection_gone {
-                                    return;
-                                }
-                            }
-                            Err(err) => {
-                                // Consume a task
-                                if rx.recv().await.is_ok() {
-                                    report_tx.send(Err(err)).unwrap();
-                                } else {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        work_queue.await.unwrap();
-        for f in futures {
-            let _ = f.await;
-        }
-    } else {
-        let futures = (0..n_connections)
-            .map(|_| {
-                let client = client.clone();
-                let mut client_state = ClientStateHttp1::default();
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                tokio::spawn(async move {
-                    while let Ok(start) = rx.recv().await {
-                        let mut res = client.work_http1(&mut client_state).await;
-                        set_start_latency_correction(&mut res, start);
-                        let is_cancel = is_cancel_error(&res);
-                        report_tx.send(res).unwrap();
-                        if is_cancel {
-                            break;
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        work_queue.await.unwrap();
-        for f in futures {
-            let _ = f.await;
+    let futures = match client.work_type() {
+        HttpWorkType::H1 => parallel_work_http1(n_connections, rx, report_tx, client, None).await,
+        HttpWorkType::H2 => {
+            parallel_work_http2(n_connections, n_http2_parallel, rx, report_tx, client, None).await
         }
     };
+    work_queue.await.unwrap();
+    for f in futures {
+        let _ = f.await;
+    }
 }
 
 /// Run until dead_line by n workers
@@ -1415,138 +1345,142 @@ pub async fn work_until(
     n_http2_parallel: usize,
     wait_ongoing_requests_after_deadline: bool,
 ) {
-    if client.is_work_http2() {
-        // Using semaphore to control the deadline
-        // Maybe there is a better concurrent primitive to do this
-        let s = Arc::new(tokio::sync::Semaphore::new(0));
+    match client.work_type() {
+        HttpWorkType::H2 => {
+            // Using semaphore to control the deadline
+            // Maybe there is a better concurrent primitive to do this
+            let s = Arc::new(tokio::sync::Semaphore::new(0));
 
-        let futures = (0..n_connections)
-            .map(|_| {
-                let client = client.clone();
-                let report_tx = report_tx.clone();
-                let s = s.clone();
-                tokio::spawn(async move {
+            let futures = (0..n_connections)
+                .map(|_| {
+                    let client = client.clone();
+                    let report_tx = report_tx.clone();
                     let s = s.clone();
-                    // Keep trying to establish or re-establish connections up to the deadline
-                    loop {
-                        match setup_http2(&client).await {
-                            Ok((connection_time, send_request)) => {
-                                // Setup the parallel workers for each HTTP2 connection
-                                let futures = (0..n_http2_parallel)
-                                    .map(|_| {
-                                        let client = client.clone();
-                                        let report_tx = report_tx.clone();
-                                        let mut client_state = ClientStateHttp2 {
-                                            rng: SeedableRng::from_os_rng(),
-                                            send_request: send_request.clone(),
-                                        };
-                                        let s = s.clone();
-                                        tokio::spawn(async move {
-                                            // This is where HTTP2 loops to make all the requests for a given client and worker
-                                            loop {
-                                                let (is_cancel, is_reconnect) = work_http2_once(
-                                                    &client,
-                                                    &mut client_state,
-                                                    &report_tx,
-                                                    connection_time,
-                                                    None,
-                                                )
-                                                .await;
+                    tokio::spawn(async move {
+                        let s = s.clone();
+                        // Keep trying to establish or re-establish connections up to the deadline
+                        loop {
+                            match setup_http2(&client).await {
+                                Ok((connection_time, send_request)) => {
+                                    // Setup the parallel workers for each HTTP2 connection
+                                    let futures = (0..n_http2_parallel)
+                                        .map(|_| {
+                                            let client = client.clone();
+                                            let report_tx = report_tx.clone();
+                                            let mut client_state = ClientStateHttp2 {
+                                                rng: SeedableRng::from_os_rng(),
+                                                send_request: send_request.clone(),
+                                            };
+                                            let s = s.clone();
+                                            tokio::spawn(async move {
+                                                // This is where HTTP2 loops to make all the requests for a given client and worker
+                                                loop {
+                                                    let (is_cancel, is_reconnect) =
+                                                        work_http2_once(
+                                                            &client,
+                                                            &mut client_state,
+                                                            &report_tx,
+                                                            connection_time,
+                                                            None,
+                                                        )
+                                                        .await;
 
-                                                let is_cancel = is_cancel || s.is_closed();
-                                                if is_cancel || is_reconnect {
-                                                    break is_cancel;
+                                                    let is_cancel = is_cancel || s.is_closed();
+                                                    if is_cancel || is_reconnect {
+                                                        break is_cancel;
+                                                    }
                                                 }
-                                            }
+                                            })
                                         })
-                                    })
-                                    .collect::<Vec<_>>();
+                                        .collect::<Vec<_>>();
 
-                                let mut connection_gone = false;
-                                for f in futures {
-                                    tokio::select! {
-                                        r = f => {
-                                            match r {
-                                                Ok(true) => {
-                                                    // All works done
-                                                    connection_gone = true;
+                                    let mut connection_gone = false;
+                                    for f in futures {
+                                        tokio::select! {
+                                            r = f => {
+                                                match r {
+                                                    Ok(true) => {
+                                                        // All works done
+                                                        connection_gone = true;
+                                                    }
+                                                    Err(_) => {
+                                                        // Unexpected
+                                                        connection_gone = true;
+                                                    }
+                                                    _ => {}
                                                 }
-                                                Err(_) => {
-                                                    // Unexpected
-                                                    connection_gone = true;
-                                                }
-                                                _ => {}
                                             }
-                                        }
-                                        _ = s.acquire() => {
-                                            report_tx.send(Err(ClientError::Deadline)).unwrap();
-                                            connection_gone = true;
+                                            _ = s.acquire() => {
+                                                report_tx.send(Err(ClientError::Deadline)).unwrap();
+                                                connection_gone = true;
+                                            }
                                         }
                                     }
+                                    if connection_gone {
+                                        return;
+                                    }
                                 }
-                                if connection_gone {
-                                    return;
-                                }
-                            }
 
-                            Err(err) => {
-                                report_tx.send(Err(err)).unwrap();
-                                if s.is_closed() {
-                                    break;
+                                Err(err) => {
+                                    report_tx.send(Err(err)).unwrap();
+                                    if s.is_closed() {
+                                        break;
+                                    }
                                 }
                             }
                         }
-                    }
+                    })
                 })
-            })
-            .collect::<Vec<_>>();
+                .collect::<Vec<_>>();
 
-        tokio::time::sleep_until(dead_line.into()).await;
-        s.close();
+            tokio::time::sleep_until(dead_line.into()).await;
+            s.close();
 
-        for f in futures {
-            let _ = f.await;
-        }
-    } else {
-        let is_end = Arc::new(AtomicBool::new(false));
-
-        let futures = (0..n_connections)
-            .map(|_| {
-                let client = client.clone();
-                let report_tx = report_tx.clone();
-                let mut client_state = ClientStateHttp1::default();
-                let is_end = is_end.clone();
-                tokio::spawn(async move {
-                    loop {
-                        let res = client.work_http1(&mut client_state).await;
-                        let is_cancel = is_cancel_error(&res);
-                        report_tx.send(res).unwrap();
-                        if is_cancel || is_end.load(Relaxed) {
-                            break;
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        tokio::time::sleep_until(dead_line.into()).await;
-        is_end.store(true, Relaxed);
-
-        if wait_ongoing_requests_after_deadline {
             for f in futures {
                 let _ = f.await;
             }
-        } else {
-            for f in futures {
-                f.abort();
-                if let Err(e) = f.await {
-                    if e.is_cancelled() {
-                        report_tx.send(Err(ClientError::Deadline)).unwrap();
+        }
+        HttpWorkType::H1 => {
+            let is_end = Arc::new(AtomicBool::new(false));
+
+            let futures = (0..n_connections)
+                .map(|_| {
+                    let client = client.clone();
+                    let report_tx = report_tx.clone();
+                    let mut client_state = ClientStateHttp1::default();
+                    let is_end = is_end.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            let res = client.work_http1(&mut client_state).await;
+                            let is_cancel = is_cancel_error(&res);
+                            report_tx.send(res).unwrap();
+                            if is_cancel || is_end.load(Relaxed) {
+                                break;
+                            }
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            tokio::time::sleep_until(dead_line.into()).await;
+            is_end.store(true, Relaxed);
+
+            if wait_ongoing_requests_after_deadline {
+                for f in futures {
+                    let _ = f.await;
+                }
+            } else {
+                for f in futures {
+                    f.abort();
+                    if let Err(e) = f.await {
+                        if e.is_cancelled() {
+                            report_tx.send(Err(ClientError::Deadline)).unwrap();
+                        }
                     }
                 }
             }
         }
-    };
+    }
 }
 
 /// Run until dead_line by n workers limit to qps works in a second
@@ -1573,7 +1507,7 @@ pub async fn work_until_with_qps(
                         (start + std::time::Duration::from_secs_f64(i as f64 * 1f64 / qps)).into(),
                     )
                     .await;
-                    let _ = tx.send(());
+                    let _ = tx.send(None);
                 }
                 // tx gone
             });
@@ -1590,7 +1524,7 @@ pub async fn work_until_with_qps(
 
                     tokio::time::sleep(duration).await;
                     for _ in 0..rate {
-                        let _ = tx.send(());
+                        let _ = tx.send(None);
                     }
                 }
                 // tx gone
@@ -1600,138 +1534,41 @@ pub async fn work_until_with_qps(
     };
 
     let rx = rx.to_async();
-    if client.is_work_http2() {
-        let s = Arc::new(tokio::sync::Semaphore::new(0));
-
-        let futures = (0..n_connections)
-            .map(|_| {
-                let client = client.clone();
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                let s = s.clone();
-                tokio::spawn(async move {
-                    loop {
-                        match setup_http2(&client).await {
-                            Ok((connection_time, send_request)) => {
-                                let futures = (0..n_http2_parallel)
-                                    .map(|_| {
-                                        let client = client.clone();
-                                        let report_tx = report_tx.clone();
-                                        let rx = rx.clone();
-                                        let mut client_state = ClientStateHttp2 {
-                                            rng: SeedableRng::from_os_rng(),
-                                            send_request: send_request.clone(),
-                                        };
-                                        let s = s.clone();
-                                        tokio::spawn(async move {
-                                            while let Ok(()) = rx.recv().await {
-                                                let (is_cancel, is_reconnect) = work_http2_once(
-                                                    &client,
-                                                    &mut client_state,
-                                                    &report_tx,
-                                                    connection_time,
-                                                    None,
-                                                )
-                                                .await;
-
-                                                let is_cancel = is_cancel || s.is_closed();
-                                                if is_cancel || is_reconnect {
-                                                    return is_cancel;
-                                                }
-                                            }
-                                            true
-                                        })
-                                    })
-                                    .collect::<Vec<_>>();
-                                let mut connection_gone = false;
-                                for f in futures {
-                                    tokio::select! {
-                                        r = f => {
-                                            match r {
-                                                Ok(true) => {
-                                                    // All works done
-                                                    connection_gone = true;
-                                                }
-                                                Err(_) => {
-                                                    // Unexpected
-                                                    connection_gone = true;
-                                                }
-                                                _ => {}
-                                            }
-                                        }
-                                        _ = s.acquire() => {
-                                            report_tx.send(Err(ClientError::Deadline)).unwrap();
-                                            connection_gone = true;
-                                        }
-                                    }
-                                }
-                                if connection_gone {
-                                    return;
-                                }
-                            }
-                            Err(err) => {
-                                // Consume a task
-                                if rx.recv().await.is_ok() {
-                                    report_tx.send(Err(err)).unwrap();
-                                } else {
-                                    return;
-                                }
-
-                                if s.is_closed() {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        tokio::time::sleep_until(dead_line.into()).await;
-        s.close();
-
-        for f in futures {
-            let _ = f.await;
+    let futures = match client.work_type() {
+        HttpWorkType::H2 => {
+            parallel_work_http2(
+                n_connections,
+                n_http2_parallel,
+                rx,
+                report_tx.clone(),
+                client.clone(),
+                Some(dead_line),
+            )
+            .await
         }
-    } else {
-        let is_end = Arc::new(AtomicBool::new(false));
-
-        let futures = (0..n_connections)
-            .map(|_| {
-                let client = client.clone();
-                let mut client_state = ClientStateHttp1::default();
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                let is_end = is_end.clone();
-                tokio::spawn(async move {
-                    while let Ok(()) = rx.recv().await {
-                        let res = client.work_http1(&mut client_state).await;
-                        let is_cancel = is_cancel_error(&res);
-                        report_tx.send(res).unwrap();
-                        if is_cancel || is_end.load(Relaxed) {
-                            break;
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        tokio::time::sleep_until(dead_line.into()).await;
-        is_end.store(true, Relaxed);
-
-        if wait_ongoing_requests_after_deadline {
-            for f in futures {
-                let _ = f.await;
-            }
-        } else {
-            for f in futures {
-                f.abort();
-                if let Err(e) = f.await {
-                    if e.is_cancelled() {
-                        report_tx.send(Err(ClientError::Deadline)).unwrap();
-                    }
+        HttpWorkType::H1 => {
+            parallel_work_http1(
+                n_connections,
+                rx,
+                report_tx.clone(),
+                client.clone(),
+                Some(dead_line),
+            )
+            .await
+        }
+    };
+    if client.work_type() == HttpWorkType::H1 && !wait_ongoing_requests_after_deadline {
+        for f in futures {
+            f.abort();
+            if let Err(e) = f.await {
+                if e.is_cancelled() {
+                    report_tx.send(Err(ClientError::Deadline)).unwrap();
                 }
             }
+        }
+    } else {
+        for f in futures {
+            let _ = f.await;
         }
     }
 }
@@ -1761,7 +1598,7 @@ pub async fn work_until_with_qps_latency_correction(
                     if now > dead_line {
                         break;
                     }
-                    let _ = tx.send(now);
+                    let _ = tx.send(Some(now));
                 }
                 // tx gone
             });
@@ -1777,7 +1614,7 @@ pub async fn work_until_with_qps_latency_correction(
                     }
 
                     for _ in 0..rate {
-                        let _ = tx.send(now);
+                        let _ = tx.send(Some(now));
                     }
                 }
                 // tx gone
@@ -1786,152 +1623,62 @@ pub async fn work_until_with_qps_latency_correction(
     };
 
     let rx = rx.to_async();
-    if client.is_work_http2() {
-        let s = Arc::new(tokio::sync::Semaphore::new(0));
-
-        let futures = (0..n_connections)
-            .map(|_| {
-                let client = client.clone();
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                let s = s.clone();
-                tokio::spawn(async move {
-                    loop {
-                        match setup_http2(&client).await {
-                            Ok((connection_time, send_request)) => {
-                                let futures = (0..n_http2_parallel)
-                                    .map(|_| {
-                                        let client = client.clone();
-                                        let report_tx = report_tx.clone();
-                                        let rx = rx.clone();
-                                        let mut client_state = ClientStateHttp2 {
-                                            rng: SeedableRng::from_os_rng(),
-                                            send_request: send_request.clone(),
-                                        };
-                                        let s = s.clone();
-                                        tokio::spawn(async move {
-                                            while let Ok(start) = rx.recv().await {
-                                                let (is_cancel, is_reconnect) = work_http2_once(
-                                                    &client,
-                                                    &mut client_state,
-                                                    &report_tx,
-                                                    connection_time,
-                                                    Some(start),
-                                                )
-                                                .await;
-                                                let is_cancel = is_cancel || s.is_closed();
-                                                if is_cancel || is_reconnect {
-                                                    return is_cancel;
-                                                }
-                                            }
-                                            true
-                                        })
-                                    })
-                                    .collect::<Vec<_>>();
-                                let mut connection_gone = false;
-                                for f in futures {
-                                    tokio::select! {
-                                        r = f => {
-                                            match r {
-                                                Ok(true) => {
-                                                    // All works done
-                                                    connection_gone = true;
-                                                }
-                                                Err(_) => {
-                                                    // Unexpected
-                                                    connection_gone = true;
-                                                }
-                                                _ => {}
-                                            }
-                                        }
-                                        _ = s.acquire() => {
-                                            report_tx.send(Err(ClientError::Deadline)).unwrap();
-                                            connection_gone = true;
-                                        }
-                                    }
-                                }
-                                if connection_gone {
-                                    return;
-                                }
-                            }
-
-                            Err(err) => {
-                                if rx.recv().await.is_ok() {
-                                    report_tx.send(Err(err)).unwrap();
-                                } else {
-                                    return;
-                                }
-
-                                if s.is_closed() {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        tokio::time::sleep_until(dead_line.into()).await;
-        s.close();
-
-        for f in futures {
-            let _ = f.await;
+    let futures = match client.work_type() {
+        HttpWorkType::H2 => {
+            parallel_work_http2(
+                n_connections,
+                n_http2_parallel,
+                rx,
+                report_tx.clone(),
+                client.clone(),
+                Some(dead_line),
+            )
+            .await
         }
-    } else {
-        let is_end = Arc::new(AtomicBool::new(false));
-
-        let futures = (0..n_connections)
-            .map(|_| {
-                let client = client.clone();
-                let mut client_state = ClientStateHttp1::default();
-                let report_tx = report_tx.clone();
-                let rx = rx.clone();
-                let is_end = is_end.clone();
-                tokio::spawn(async move {
-                    while let Ok(start) = rx.recv().await {
-                        let mut res = client.work_http1(&mut client_state).await;
-                        set_start_latency_correction(&mut res, start);
-                        let is_cancel = is_cancel_error(&res);
-                        report_tx.send(res).unwrap();
-                        if is_cancel || is_end.load(Relaxed) {
-                            break;
-                        }
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        tokio::time::sleep_until(dead_line.into()).await;
-        is_end.store(true, Relaxed);
-
-        if wait_ongoing_requests_after_deadline {
-            for f in futures {
-                let _ = f.await;
-            }
-        } else {
-            for f in futures {
-                f.abort();
-                if let Err(e) = f.await {
-                    if e.is_cancelled() {
-                        report_tx.send(Err(ClientError::Deadline)).unwrap();
-                    }
+        HttpWorkType::H1 => {
+            parallel_work_http1(
+                n_connections,
+                rx,
+                report_tx.clone(),
+                client.clone(),
+                Some(dead_line),
+            )
+            .await
+        }
+    };
+    if client.work_type() == HttpWorkType::H1 && !wait_ongoing_requests_after_deadline {
+        for f in futures {
+            f.abort();
+            if let Err(e) = f.await {
+                if e.is_cancelled() {
+                    report_tx.send(Err(ClientError::Deadline)).unwrap();
                 }
             }
+        }
+    } else {
+        for f in futures {
+            let _ = f.await;
         }
     }
 }
 
-/// Optimized workers for `--no-tui` mode
+/**
+ * Optimized workers for `--no-tui` mode
+ * These workers will all run on a single thread and are not `async`.
+ * Reduces tokio synchronisation overhead.
+ */
 pub mod fast {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicIsize, Ordering},
+    };
 
     use rand::SeedableRng;
 
     use crate::{
         client::{
-            ClientError, ClientStateHttp1, ClientStateHttp2, is_cancel_error, is_hyper_error,
-            set_connection_time, setup_http2,
+            ClientError, ClientStateHttp1, ClientStateHttp2, HttpWorkType, is_cancel_error,
+            is_hyper_error, set_connection_time, setup_http2,
         },
         result_data::ResultData,
     };
@@ -1944,10 +1691,9 @@ pub mod fast {
         report_tx: kanal::Sender<ResultData>,
         n_tasks: usize,
         n_connections: usize,
-        n_http2_parallel: usize,
+        n_http_parallel: usize,
     ) {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        let counter = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::new(AtomicIsize::new(n_tasks as isize));
         let num_threads = num_cpus::get_physical();
         let connections = (0..num_threads).filter_map(|i| {
             let num_connection = n_connections / num_threads
@@ -1963,172 +1709,41 @@ pub mod fast {
             }
         });
         let token = tokio_util::sync::CancellationToken::new();
-
-        let handles = if client.is_work_http2() {
-            connections
-                .map(|num_connections| {
-                    let report_tx = report_tx.clone();
-                    let counter = counter.clone();
-                    let client = client.clone();
-                    let rt = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .unwrap();
-                    let token = token.clone();
-
-                    std::thread::spawn(move || {
-                        let client = client.clone();
-                        let local = tokio::task::LocalSet::new();
-                        for _ in 0..num_connections {
-                            let report_tx = report_tx.clone();
-                            let counter = counter.clone();
-                            let client = client.clone();
-                            let token = token.clone();
-                            local.spawn_local(Box::pin(async move {
-                                let mut has_err = false;
-                                let mut result_data_err = ResultData::default();
-                                loop {
-                                    let client = client.clone();
-                                    match setup_http2(&client).await {
-                                        Ok((connection_time, send_request)) => {
-                                            let futures = (0..n_http2_parallel)
-                                                .map(|_| {
-                                                    let mut client_state = ClientStateHttp2 {
-                                                        rng: SeedableRng::from_os_rng(),
-                                                        send_request: send_request.clone(),
-                                                    };
-                                                    let counter = counter.clone();
-                                                    let client = client.clone();
-                                                    let report_tx = report_tx.clone();
-                                                    let token = token.clone();
-                                                    tokio::task::spawn_local(async move {
-                                                        let mut result_data = ResultData::default();
-
-                                                        let work = async {
-                                                            while counter
-                                                                .fetch_add(1, Ordering::Relaxed)
-                                                                < n_tasks
-                                                            {
-                                                                let mut res = client
-                                                                    .work_http2(&mut client_state)
-                                                                    .await;
-                                                                let is_cancel =
-                                                                    is_cancel_error(&res);
-                                                                let is_reconnect =
-                                                                    is_hyper_error(&res);
-                                                                set_connection_time(
-                                                                    &mut res,
-                                                                    connection_time,
-                                                                );
-
-                                                                result_data.push(res);
-
-                                                                if is_cancel || is_reconnect {
-                                                                    return is_cancel;
-                                                                }
-                                                            }
-                                                            true
-                                                        };
-
-                                                        let is_cancel = tokio::select! {
-                                                            is_cancel = work => {
-                                                                is_cancel
-                                                            }
-                                                            _ = token.cancelled() => {
-                                                                true
-                                                            }
-                                                        };
-
-                                                        report_tx.send(result_data).unwrap();
-                                                        is_cancel
-                                                    })
-                                                })
-                                                .collect::<Vec<_>>();
-
-                                            let mut connection_gone = false;
-                                            for f in futures {
-                                                match f.await {
-                                                    Ok(true) => {
-                                                        // All works done
-                                                        connection_gone = true;
-                                                    }
-                                                    Err(_) => {
-                                                        // Unexpected
-                                                        connection_gone = true;
-                                                    }
-                                                    _ => {}
-                                                }
-                                            }
-
-                                            if connection_gone {
-                                                break;
-                                            }
-                                        }
-                                        Err(err) => {
-                                            if counter.fetch_add(1, Ordering::Relaxed) < n_tasks {
-                                                has_err = true;
-                                                result_data_err.push(Err(err));
-                                            } else {
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
-                                if has_err {
-                                    report_tx.send(result_data_err).unwrap();
-                                }
-                            }));
-                        }
-
-                        rt.block_on(local);
-                    })
+        let handles = connections
+            .map(|num_connections| {
+                let report_tx = report_tx.clone();
+                let client = client.clone();
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                let token = token.clone();
+                let counter = counter.clone();
+                // will let is_end just stay false permanently
+                let is_end = Arc::new(AtomicBool::new(false));
+                std::thread::spawn(move || match client.work_type() {
+                    HttpWorkType::H2 => http2_connection_fast_work_until(
+                        num_connections,
+                        n_http_parallel,
+                        report_tx,
+                        client,
+                        token,
+                        Some(counter),
+                        is_end,
+                        rt,
+                    ),
+                    HttpWorkType::H1 => http1_connection_fast_work_until(
+                        num_connections,
+                        report_tx,
+                        client,
+                        token,
+                        Some(counter),
+                        is_end,
+                        rt,
+                    ),
                 })
-                .collect::<Vec<_>>()
-        } else {
-            connections
-                .map(|num_connection| {
-                    let report_tx = report_tx.clone();
-                    let counter = counter.clone();
-                    let client = client.clone();
-                    let rt = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .unwrap();
-
-                    let token = token.clone();
-                    std::thread::spawn(move || {
-                        let local = tokio::task::LocalSet::new();
-
-                        for _ in 0..num_connection {
-                            let report_tx = report_tx.clone();
-                            let counter = counter.clone();
-                            let client = client.clone();
-                            let token = token.clone();
-                            local.spawn_local(Box::pin(async move {
-                                let mut result_data = ResultData::default();
-
-                                tokio::select! {
-                                    _ = token.cancelled() => {}
-                                    _ = async {
-                                        let mut client_state = ClientStateHttp1::default();
-                                        while counter.fetch_add(1, Ordering::Relaxed) < n_tasks {
-                                            let res = client.work_http1(&mut client_state).await;
-                                            let is_cancel = is_cancel_error(&res);
-                                            result_data.push(res);
-                                            if is_cancel {
-                                                break;
-                                            }
-                                        }
-                                    } => {}
-                                }
-                                report_tx.send(result_data).unwrap();
-                            }));
-                        }
-                        rt.block_on(local);
-                    })
-                })
-                .collect::<Vec<_>>()
-        };
+            })
+            .collect::<Vec<_>>();
 
         tokio::spawn(async move {
             tokio::signal::ctrl_c().await.unwrap();
@@ -2148,10 +1763,9 @@ pub mod fast {
         report_tx: kanal::Sender<ResultData>,
         dead_line: std::time::Instant,
         n_connections: usize,
-        n_http2_parallel: usize,
+        n_http_parallel: usize,
         wait_ongoing_requests_after_deadline: bool,
     ) {
-        use std::sync::atomic::{AtomicBool, Ordering};
         let num_threads = num_cpus::get_physical();
 
         let is_end = Arc::new(AtomicBool::new(false));
@@ -2169,8 +1783,7 @@ pub mod fast {
             }
         });
         let token = tokio_util::sync::CancellationToken::new();
-        let handles = if client.is_work_http2() {
-            connections
+        let handles = connections
             .map(|num_connections| {
                 let report_tx = report_tx.clone();
                 let client = client.clone();
@@ -2180,159 +1793,29 @@ pub mod fast {
                     .unwrap();
                 let token = token.clone();
                 let is_end = is_end.clone();
-
-                std::thread::spawn(move || {
-                    let client = client.clone();
-                    let local = tokio::task::LocalSet::new();
-                    for _ in 0..num_connections {
-                        let report_tx = report_tx.clone();
-                        let client = client.clone();
-                        let token = token.clone();
-                        let is_end = is_end.clone();
-                        local.spawn_local(Box::pin(async move {
-                            let mut has_err = false;
-                            let mut result_data_err = ResultData::default();
-                            loop {
-                                let client = client.clone();
-                                match setup_http2(&client).await {
-                                    Ok((connection_time, send_request)) => {
-                                        let futures = (0..n_http2_parallel)
-                                            .map(|_| {
-                                                let mut client_state = ClientStateHttp2 {
-                                                    rng: SeedableRng::from_os_rng(),
-                                                    send_request: send_request.clone(),
-                                                };
-                                                let client = client.clone();
-                                                let report_tx = report_tx.clone();
-                                                let token = token.clone();
-                                                let is_end = is_end.clone();
-                                                tokio::task::spawn_local(async move {
-                                                    let mut result_data = ResultData::default();
-
-                                                    let work = async {
-                                                        loop {
-                                                            let mut res = client
-                                                                .work_http2(&mut client_state)
-                                                                .await;
-                                                            let is_cancel = is_cancel_error(&res) || is_end.load(Ordering::Relaxed);
-                                                            let is_reconnect = is_hyper_error(&res);
-                                                            set_connection_time(
-                                                                &mut res,
-                                                                connection_time,
-                                                            );
-
-                                                            result_data.push(res);
-
-                                                            if is_cancel || is_reconnect {
-                                                                return is_cancel;
-                                                            }
-                                                        }
-                                                    };
-
-                                                    let is_cancel = tokio::select! {
-                                                        is_cancel = work => {
-                                                            is_cancel
-                                                        }
-                                                        _ = token.cancelled() => {
-                                                            result_data.push(Err(ClientError::Deadline));
-                                                            true
-                                                        }
-                                                    };
-
-                                                    report_tx.send(result_data).unwrap();
-                                                    is_cancel
-                                                })
-                                            })
-                                            .collect::<Vec<_>>();
-
-                                        let mut connection_gone = false;
-                                        for f in futures {
-                                            match f.await {
-                                                Ok(true) => {
-                                                    // All works done
-                                                    connection_gone = true;
-                                                }
-                                                Err(_) => {
-                                                    // Unexpected
-                                                    connection_gone = true;
-                                                }
-                                                _ => {}
-                                            }
-                                        }
-
-                                        if connection_gone {
-                                            break;
-                                        }
-                                    }
-                                    Err(err) => {
-                                        has_err = true;
-                                        result_data_err.push(Err(err));
-                                        if is_end.load(Ordering::Relaxed) {
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                            if has_err {
-                                report_tx.send(result_data_err).unwrap();
-                            }
-                        }));
-                    }
-
-                    rt.block_on(local);
+                std::thread::spawn(move || match client.work_type() {
+                    HttpWorkType::H2 => http2_connection_fast_work_until(
+                        num_connections,
+                        n_http_parallel,
+                        report_tx,
+                        client,
+                        token,
+                        None,
+                        is_end,
+                        rt,
+                    ),
+                    HttpWorkType::H1 => http1_connection_fast_work_until(
+                        num_connections,
+                        report_tx,
+                        client,
+                        token,
+                        None,
+                        is_end,
+                        rt,
+                    ),
                 })
             })
-            .collect::<Vec<_>>()
-        } else {
-            connections
-                .map(|num_connection| {
-                    let report_tx = report_tx.clone();
-                    let is_end = is_end.clone();
-                    let client = client.clone();
-                    let rt = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .unwrap();
-
-                    let token = token.clone();
-                    std::thread::spawn(move || {
-                        let local = tokio::task::LocalSet::new();
-
-                        for _ in 0..num_connection {
-                            let report_tx = report_tx.clone();
-                            let is_end = is_end.clone();
-                            let client = client.clone();
-                            let token = token.clone();
-                            local.spawn_local(Box::pin(async move {
-                                let mut result_data = ResultData::default();
-
-                                let work = async {
-                                    let mut client_state = ClientStateHttp1::default();
-                                    loop {
-                                        let res = client.work_http1(&mut client_state).await;
-                                        let is_cancel = is_cancel_error(&res);
-                                        result_data.push(res);
-                                        if is_cancel || is_end.load(Ordering::Relaxed) {
-                                            break;
-                                        }
-                                    }
-                                };
-
-                                tokio::select! {
-                                    _ = work => {
-                                    }
-                                    _ = token.cancelled() => {
-                                        result_data.push(Err(ClientError::Deadline));
-                                    }
-                                }
-                                report_tx.send(result_data).unwrap();
-                            }));
-                        }
-                        rt.block_on(local);
-                    })
-                })
-                .collect::<Vec<_>>()
-        };
+            .collect::<Vec<_>>();
         tokio::select! {
             _ = tokio::time::sleep_until(dead_line.into()) => {
             }
@@ -2350,5 +1833,186 @@ pub mod fast {
                 let _ = handle.join();
             }
         });
+    }
+
+    /**
+     * Generalised HTTP2 work function. Can be terminated in the following ways:
+     *  * Set `is_end` to true. This happens when we reach a 'deadline', or are counting for a fixed period of time.
+     *  * The cancellation token can also be triggered for a similar effect. These can likely be combined into one in a future CR.
+     *  * pass a value for counter. It will count down to 0, and terminate.
+     */
+    #[allow(clippy::too_many_arguments)]
+    fn http2_connection_fast_work_until(
+        num_connections: usize,
+        n_http_parallel: usize,
+        report_tx: kanal::Sender<ResultData>,
+        client: Arc<Client>,
+        token: tokio_util::sync::CancellationToken,
+        counter: Option<Arc<AtomicIsize>>,
+        is_end: Arc<AtomicBool>,
+        rt: tokio::runtime::Runtime,
+    ) {
+        let is_counting_tasks = counter.is_some();
+        let client = client.clone();
+        let local = tokio::task::LocalSet::new();
+        for _ in 0..num_connections {
+            let report_tx = report_tx.clone();
+            let client = client.clone();
+            let token = token.clone();
+            let is_end = is_end.clone();
+            let counter = counter.clone();
+            local.spawn_local(Box::pin(async move {
+                let mut has_err = false;
+                let mut result_data_err = ResultData::default();
+                loop {
+                    let client = client.clone();
+                    match setup_http2(&client).await {
+                        Ok((connection_time, send_request)) => {
+                            let futures = (0..n_http_parallel)
+                                .map(|_| {
+                                    let mut client_state = ClientStateHttp2 {
+                                        rng: SeedableRng::from_os_rng(),
+                                        send_request: send_request.clone(),
+                                    };
+                                    let client = client.clone();
+                                    let report_tx = report_tx.clone();
+                                    let token = token.clone();
+                                    let is_end = is_end.clone();
+                                    let counter = counter.clone();
+                                    tokio::task::spawn_local(async move {
+                                        let mut result_data = ResultData::default();
+
+                                        let work = async {
+                                            loop {
+                                                if is_counting_tasks
+                                                    && counter
+                                                        .as_ref()
+                                                        .unwrap()
+                                                        .fetch_sub(1, Ordering::Relaxed)
+                                                        <= 0
+                                                {
+                                                    return true;
+                                                }
+                                                let mut res =
+                                                    client.work_http2(&mut client_state).await;
+                                                let is_cancel = is_cancel_error(&res)
+                                                    || is_end.load(Ordering::Relaxed);
+                                                let is_reconnect = is_hyper_error(&res);
+                                                set_connection_time(&mut res, connection_time);
+
+                                                result_data.push(res);
+
+                                                if is_cancel || is_reconnect {
+                                                    return is_cancel;
+                                                }
+                                            }
+                                        };
+
+                                        let is_cancel = tokio::select! {
+                                            is_cancel = work => {
+                                                is_cancel
+                                            }
+                                            _ = token.cancelled() => {
+                                                result_data.push(Err(ClientError::Deadline));
+                                                true
+                                            }
+                                        };
+
+                                        report_tx.send(result_data).unwrap();
+                                        is_cancel
+                                    })
+                                })
+                                .collect::<Vec<_>>();
+
+                            let mut connection_gone = false;
+                            for f in futures {
+                                match f.await {
+                                    Ok(true) => {
+                                        // All works done
+                                        connection_gone = true;
+                                    }
+                                    Err(_) => {
+                                        // Unexpected
+                                        connection_gone = true;
+                                    }
+                                    _ => {}
+                                }
+                            }
+
+                            if connection_gone {
+                                break;
+                            }
+                        }
+                        Err(err) => {
+                            has_err = true;
+                            result_data_err.push(Err(err));
+                            if is_end.load(Ordering::Relaxed)
+                                || (is_counting_tasks
+                                    && counter.as_ref().unwrap().fetch_sub(1, Ordering::Relaxed)
+                                        <= 0)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+                if has_err {
+                    report_tx.send(result_data_err).unwrap();
+                }
+            }));
+        }
+
+        rt.block_on(local);
+    }
+
+    fn http1_connection_fast_work_until(
+        num_connections: usize,
+        report_tx: kanal::Sender<ResultData>,
+        client: Arc<Client>,
+        token: tokio_util::sync::CancellationToken,
+        counter: Option<Arc<AtomicIsize>>,
+        is_end: Arc<AtomicBool>,
+        rt: tokio::runtime::Runtime,
+    ) {
+        let is_counting_tasks = counter.is_some();
+        let local = tokio::task::LocalSet::new();
+
+        for _ in 0..num_connections {
+            let report_tx = report_tx.clone();
+            let is_end = is_end.clone();
+            let counter = counter.clone();
+            let client = client.clone();
+            let token = token.clone();
+            local.spawn_local(Box::pin(async move {
+                let mut result_data = ResultData::default();
+
+                let work = async {
+                    let mut client_state = ClientStateHttp1::default();
+                    loop {
+                        if is_counting_tasks
+                            && counter.as_ref().unwrap().fetch_sub(1, Ordering::Relaxed) <= 0
+                        {
+                            break;
+                        }
+                        let res = client.work_http1(&mut client_state).await;
+                        let is_cancel = is_cancel_error(&res);
+                        result_data.push(res);
+                        if is_cancel || is_end.load(Ordering::Relaxed) {
+                            break;
+                        }
+                    }
+                };
+
+                tokio::select! {
+                    _ = work => {
+                    }
+                    _ = token.cancelled() => {
+                        result_data.push(Err(ClientError::Deadline));
+                    }
+                }
+                report_tx.send(result_data).unwrap();
+            }));
+        }
+        rt.block_on(local);
     }
 }

--- a/src/tls_config.rs
+++ b/src/tls_config.rs
@@ -54,11 +54,12 @@ impl RuslsConfigs {
         }
     }
 
-    pub fn config(&self, is_http2: bool) -> &std::sync::Arc<rustls::ClientConfig> {
-        if is_http2 {
-            &self.alpn_h2
-        } else {
-            &self.no_alpn
+    pub fn config(&self, http: hyper::http::Version) -> &std::sync::Arc<rustls::ClientConfig> {
+        use hyper::http::Version;
+        match http {
+            Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11 => &self.no_alpn,
+            Version::HTTP_2 => &self.alpn_h2,
+            _ => panic!("nonsupported HTTP version"),
         }
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -43,8 +43,7 @@ async fn get_req(path: &str, args: &[&str]) -> Request<hyper::body::Incoming> {
 
     let (listener, port) = bind_port().await;
 
-    let http2 = args.iter().any(|&arg| arg == "--http2")
-        || args.windows(2).any(|w| w == ["--http-version", "2"]);
+    let http2 = args.contains(&"--http2") || args.windows(2).any(|w| w == ["--http-version", "2"]);
 
     tokio::spawn(async move {
         if http2 {


### PR DESCRIPTION
Hi,
A bigger change here but I hope it is valuable! We want to contribute HTTP/3 support to Oha. This is an initial CR which refactors the `client.rs` to use common functions for http1 and http2 load generation. 
It also introduces a HttpWorkType enum which is matched on to choose which functionality to execute, rather than the previous is_http2() function. 

This lays the groundwork for adding a H3 work type in a following PR, and a http3 load generation common function.
This will be feature gated due to its experimental nature. 
This has been split off into a separate PR to make them easier to understand and review individually. It's nice to be able to have a refactor PR which doesn't need to change any tests - it is internal structural changes only. 

This PR has had an initial review here https://github.com/gseddon/oha/pull/1
and here is the HTTP3 branch, will make that PR once this one is merged https://github.com/gseddon/oha/pull/2 