### PR TITLE
Allow appending to database if oha table has already been created

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -4,14 +4,15 @@ use crate::client::{Client, RequestResult};
 
 fn create_db(conn: &Connection) -> Result<usize, rusqlite::Error> {
     conn.execute(
-        "CREATE TABLE oha (
+        "CREATE TABLE IF NOT EXISTS oha (
             url TEXT NOT NULL,
             start REAL NOT NULL,
             start_latency_correction REAL,
             end REAL NOT NULL,
             duration REAL NOT NULL,
             status INTEGER NOT NULL,
-            len_bytes INTEGER NOT NULL
+            len_bytes INTEGER NOT NULL,
+            run INTEGER NOT NULL
         )",
         (),
     )
@@ -22,6 +23,7 @@ pub fn store(
     db_url: &str,
     start: std::time::Instant,
     request_records: &[RequestResult],
+    run: u64,
 ) -> Result<usize, rusqlite::Error> {
     let mut conn = Connection::open(db_url)?;
     create_db(&conn)?;
@@ -32,7 +34,7 @@ pub fn store(
     for request in request_records {
         let url = client.generate_url(&mut request.rng.clone()).unwrap().0;
         affected_rows += t.execute(
-            "INSERT INTO oha (url, start, start_latency_correction, end, duration, status, len_bytes) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO oha (url, start, start_latency_correction, end, duration, status, len_bytes, run) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             (
                 url.to_string(),
                 (request.start - start).as_secs_f64(),
@@ -41,6 +43,7 @@ pub fn store(
                 request.duration().as_secs_f64(),
                 request.status.as_u16() as i64,
                 request.len_bytes,
+                run
             ),
         )?;
     }
@@ -58,6 +61,10 @@ mod test_db {
 
     #[test]
     fn test_store() {
+        let run = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         let start = std::time::Instant::now();
         let test_val = RequestResult {
             rng: SeedableRng::seed_from_u64(0),
@@ -71,7 +78,7 @@ mod test_db {
         };
         let test_vec = vec![test_val.clone(), test_val.clone()];
         let client = Client::default();
-        let result = store(&client, ":memory:", start, &test_vec);
+        let result = store(&client, ":memory:", start, &test_vec, run);
         assert_eq!(result.unwrap(), 2);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,6 +622,9 @@ pub async fn run(mut opts: Opts) -> anyhow::Result<()> {
         }
     };
 
+    let run = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_secs();
     let start = std::time::Instant::now();
 
     let data_collect_future: Pin<Box<dyn std::future::Future<Output = (ResultData, PrintConfig)>>> =
@@ -846,7 +849,7 @@ pub async fn run(mut opts: Opts) -> anyhow::Result<()> {
 
     if let Some(db_url) = opts.db_url {
         eprintln!("Storing results to {db_url}");
-        db::store(&client, &db_url, start, res.success())?;
+        db::store(&client, &db_url, start, res.success(), run)?;
     }
 
     Ok(())


### PR DESCRIPTION
Addresses #734 

This PR goes the route I mentioned of just automatically appending to the DB without failing if the table already exists.

Namely we use

```sql
CREATE TABLE IF NOT EXISTS oha 
```

instead of 
```sql
CREATE TABLE oha 
```

Runs are separated by start time of the run which is accurate to the second. I would prefer milliseconds to reduce risk of a collision but `.as_millis()` returns `u128` which does not implement `ToSql`. If there is a better alternative suggested I can implement that.
