### PR TITLE
Add colors to --help/-h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d546f0e84ff2bfa4da1ce9b54be42285767ba39c688572ca32412a09a73851e5"
+dependencies = [
+ "anstyle",
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,6 +2350,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "clap-cargo",
  "ctor",
  "float-cmp",
  "float-ord",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ tokio-vsock = { version = "0.7.2", optional = true }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 num_cpus = "1.16.0"
 tokio-util = "0.7.13"
+clap-cargo = "0.15.2"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,12 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 #[command(arg_required_else_help(true))]
+#[command(styles = clap_cargo::style::CLAP_STYLING)]
 pub struct Opts {
     #[arg(help = "Target URL or file with multiple URLs.")]
     url: String,
     #[arg(
-        help = "Number of requests to run. Accepts plain numbers or suffixes: k = 1,000, m = 1,000,000 (e.g. 10k, 1m).", 
+        help = "Number of requests to run. Accepts plain numbers or suffixes: k = 1,000, m = 1,000,000 (e.g. 10k, 1m).",
         short = 'n',
         default_value = "200",
         conflicts_with = "duration",


### PR DESCRIPTION
I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.
User can disable colors via `NO_COLOR=1` environment variable

Output of `oha -h`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="2684" height="2476" alt="oha-before" src="https://github.com/user-attachments/assets/2898df8e-beb5-4fba-84dd-2587090f66db" /> | <img width="2684" height="2476" alt="oha-colors" src="https://github.com/user-attachments/assets/ebcd71de-75ad-4d90-b4fe-103c62197b3f" /> | <img width="2684" height="2476" alt="oha-no-color" src="https://github.com/user-attachments/assets/9e623d67-33e0-44c7-86f2-f71f8cabffa1" /> |
