### PR TITLE
fix(conn): cap connections to minimum needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -964,9 +964,15 @@ impl Opts {
                 wait_ongoing_requests_after_deadline: self.wait_ongoing_requests_after_deadline,
             }
         } else {
+            let mut n_connections = self.n_connections;
+            let max_useful = self.n_requests.div_ceil(self.n_http2_parallel);
+            if n_connections > max_useful {
+                n_connections = max_useful;
+            }
+
             WorkMode::FixedNumber {
                 n_requests: self.n_requests,
-                n_connections: self.n_connections,
+                n_connections,
                 n_http2_parallel: self.n_http2_parallel,
                 query_limit: match self.query_per_second {
                     Some(0f64) | None => self.burst_duration.map(|burst_duration| {


### PR DESCRIPTION
This PR fixes #864 

Instead of `c = min(n, c)`, we take into account `p`: `c = min(ceil(n / p), c)`

Manually tested:

```
cargo run --features http3 -- --insecure --http-version {1.1,2,3} https://localhost/ -n 3 -q 3 -p 2
```
2 per protocol

<img width="672" height="183" alt="image" src="https://github.com/user-attachments/assets/c6980a20-ec95-4429-93e0-60d5b23f20a4" />

3 per protocol
```
cargo run --features http3 -- --insecure --http-version {1.1,2,3} https://localhost/ -n 3 -q 3
```
<img width="907" height="224" alt="image" src="https://github.com/user-attachments/assets/b095ec77-76f7-4f16-9b97-009d9a9d0f3d" />


1 connection
```
cargo run --features http3 -- --insecure --http-version 2 https://localhost/ -n 3 -c 50 -p 3
```
<img width="903" height="70" alt="image" src="https://github.com/user-attachments/assets/3247f881-58df-4d61-87b4-d845c1921036" />
