### PR TITLE
Fix NO_COLOR convention regression

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,23 @@ pub fn parse_n_requests(s: &str) -> Result<usize, String> {
     }
 }
 
+pub fn parse_no_color(s: &str) -> Result<bool, String> {
+    Ok(!s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_no_color;
+
+    #[test]
+    fn test_parse_no_color() {
+        assert!(!parse_no_color("").unwrap());
+        assert!(parse_no_color("1").unwrap());
+        assert!(parse_no_color("true").unwrap());
+        assert!(parse_no_color("false").unwrap());
+    }
+}
+
 /// An entry specified by `connect-to` to override DNS resolution and default
 /// port numbers. For example, `example.org:80:localhost:5000` will connect to
 /// `localhost:5000` whenever `http://example.org` is requested.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,10 @@ Note: if used several times for the same host:port:target_host:target_port, a ra
         help = "Disable the color scheme.",
         alias = "disable-color",
         long = "no-color",
-        env = "NO_COLOR"
+        env = "NO_COLOR",
+        default_value = "",
+        default_missing_value = "true",
+        value_parser = cli::parse_no_color
     )]
     no_color: bool,
     #[cfg(unix)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,7 +11,7 @@ use std::{
 
 use axum::{Router, extract::Path, response::Redirect, routing::get};
 use bytes::Bytes;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use http::{HeaderMap, Request, Response};
 use http_body_util::BodyExt;
 use http_mitm_proxy::MitmProxy;
@@ -34,6 +34,35 @@ async fn run<'a>(args: impl Iterator<Item = &'a str>) {
     );
 
     oha::run(opts).await.unwrap();
+}
+
+#[test]
+fn test_no_color_env_convention() {
+    for value in ["1", ""] {
+        let status = std::process::Command::new(env!("CARGO_BIN_EXE_oha"))
+            .args([
+                "http://127.0.0.1:9",
+                "-n",
+                "1",
+                "--no-tui",
+                "--output-format",
+                "quiet",
+            ])
+            .env("NO_COLOR", value)
+            .status()
+            .unwrap();
+
+        assert!(status.success());
+    }
+}
+
+#[test]
+fn test_no_color_cli_flag() {
+    let matches = oha::Opts::command()
+        .mut_arg("no_color", |arg| arg.env(None))
+        .try_get_matches_from(["oha", "--no-color", "http://example.com"])
+        .unwrap();
+    assert!(matches.get_flag("no_color"));
 }
 
 // Port 5111- is reserved for testing


### PR DESCRIPTION
## Summary

`NO_COLOR` is a de-facto convention for disabling ANSI color output. The convention is presence-based: if `NO_COLOR` is present and non-empty, color should be disabled regardless of the specific value.

Reference:

- https://no-color.org/
- Archived copy: http://web.archive.org/web/20260616201813/https://no-color.org/

oha used to accept this convention, but since the `--no-color` clap/env wiring change it now parses `NO_COLOR` as a strict boolean. As a result, the common form `NO_COLOR=1` now fails during argument parsing:

```sh
NO_COLOR=1 oha http://127.0.0.1:9 -z 1s -c 1 --output-format json --no-tui
```

```text
invalid value '1' for '--no-color'
[possible values: true, false]
```

This PR restores convention-compatible `NO_COLOR` handling.

## Behavior

After this change:

- unset `NO_COLOR` does not disable color
- empty `NO_COLOR=` does not disable color
- non-empty `NO_COLOR`, including `NO_COLOR=1`, disables color
- `NO_COLOR=true` disables color
- `NO_COLOR=false` disables color
- `--no-color` continues to work

## Compatibility note

Restoring the NO_COLOR convention means this is technically a behavior change for `NO_COLOR=false`.

With the recent strict boolean parsing, `NO_COLOR=false` meant “do not disable color”. With convention-compatible parsing, `NO_COLOR=false` disables color because the variable is present and non-empty.

Users who want color should unset `NO_COLOR` or set it to an empty value.

## Tests

Added coverage for:

- `NO_COLOR=1`
- empty `NO_COLOR=`
- `NO_COLOR=true`
- `NO_COLOR=false`
- `--no-color`

Ran locally:

- `cargo test no_color -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
