### PR TITLE
Change default redirect limit to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Options:
       --disable-compression
           Disable compression.
   -r, --redirect <REDIRECT>
-          Limit for number of Redirect. Set 0 for no redirection. Redirection isn't supported for HTTP/2. [default: 10]
+          Limit for number of Redirect. Set 0 for no redirection. Redirection isn't supported for HTTP/2. [default: 0]
       --disable-keepalive
           Disable keep-alive, prevents re-use of TCP connections between different HTTP requests. This isn't supported for HTTP/2.
       --no-pre-lookup

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ Note: If qps is specified, burst will be ignored",
     disable_compression: bool,
     #[arg(
         help = "Limit for number of Redirect. Set 0 for no redirection. Redirection isn't supported for HTTP/2.",
-        default_value = "10",
+        default_value = "0",
         short = 'r',
         long = "redirect"
     )]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -352,6 +352,8 @@ async fn get_host_with_connect_to_redirect(host: &'static str) -> String {
     let args = [
         "-n".to_string(),
         "1".to_string(),
+        "-r".to_string(),
+        "10".to_string(),
         format!("http://{host}/source"),
         "--connect-to".to_string(),
         format!("{host}:80:localhost:{port}"),


### PR DESCRIPTION
## Summary

Changes the default value of `-r` / `--redirect` from `10` to `0` (no redirection).

Following redirects requires looking up the `Location` header on every response, which shows up as overhead in the hot path. Most load tests target a single endpoint and don't need redirection, so this disables it by default. Users who need it can opt back in with `-r <N>`.

## Notes

- This is a user-visible behavior change: URLs that previously got followed will now report the 3xx status instead.
- `tests/tests.rs` now passes `-r 10` explicitly in the test that exercises redirection.
- README usage output updated to match the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)