### PR TITLE
Avoid TenSeconds/TenMinutes time scales in summary output

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -503,7 +503,7 @@ fn print_summary<W: Write>(
         timescale
     } else {
         // Use max latency (slowest request)
-        TimeScale::from_f64(latency_stat.max())
+        TimeScale::from_f64_summary(latency_stat.max())
     };
     writeln!(
         w,

--- a/src/timescale.rs
+++ b/src/timescale.rs
@@ -130,6 +130,24 @@ impl TimeScale {
         TimeScale::Nanosecond
     }
 
+    /// From seconds as f64 for summary output.
+    /// TimeScale::TenSeconds and TimeScale::TenMinutes are not used for summary output. Because it is looked weird to see "10 sec" or "10 min" in summary output.
+    pub fn from_f64_summary(seconds: f64) -> Self {
+        for ts in &[
+            TimeScale::Hour,
+            TimeScale::Minute,
+            TimeScale::Second,
+            TimeScale::Millisecond,
+            TimeScale::Microsecond,
+            TimeScale::Nanosecond,
+        ] {
+            if seconds > ts.as_secs_f64() {
+                return *ts;
+            }
+        }
+        TimeScale::Nanosecond
+    }
+
     pub fn from_elapsed(duration: Duration) -> Self {
         Self::from_f64(duration.as_secs_f64())
     }


### PR DESCRIPTION
fix #890 