### PR TITLE
Add --worker-threads flag to set the runtime thread count

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ Options:
           Output format [default: text] [possible values: text, json, csv, quiet]
   -u, --time-unit <TIME_UNIT>
           Time unit to be used. If not specified, the time unit is determined automatically. This option affects only text format. [possible values: ns, us, ms, s, m, h]
+      --worker-threads <WORKER_THREADS>
+          Number of native OS threads used by the async runtime (tokio).
+          Takes precedence over the TOKIO_WORKER_THREADS environment variable. When neither is set, the number of physical CPU cores is used.
   -h, --help
           Print help
   -V, --version

--- a/src/client.rs
+++ b/src/client.rs
@@ -2204,7 +2204,7 @@ pub mod fast {
         n_tasks: usize,
         n_connections: usize,
         n_http_parallel: usize,
-        worker_threads: Option<std::num::NonZeroUsize>,
+        worker_threads: std::num::NonZeroUsize,
     ) {
         #[cfg(feature = "http3")]
         if matches!(client.work_type(), HttpWorkType::H3) {
@@ -2221,9 +2221,7 @@ pub mod fast {
         }
 
         let counter = Arc::new(AtomicIsize::new(n_tasks as isize));
-        let num_threads = worker_threads
-            .map(|n| n.get())
-            .unwrap_or_else(num_cpus::get_physical);
+        let num_threads = worker_threads.get();
         let connections = (0..num_threads).filter_map(|i| {
             let num_connection = n_connections / num_threads
                 + (if (n_connections % num_threads) > i {
@@ -2434,7 +2432,7 @@ pub mod fast {
         n_connections: usize,
         n_http_parallel: usize,
         wait_ongoing_requests_after_deadline: bool,
-        worker_threads: Option<std::num::NonZeroUsize>,
+        worker_threads: std::num::NonZeroUsize,
     ) {
         #[cfg(feature = "http3")]
         if matches!(client.work_type(), HttpWorkType::H3) {
@@ -2451,9 +2449,7 @@ pub mod fast {
             return;
         }
 
-        let num_threads = worker_threads
-            .map(|n| n.get())
-            .unwrap_or_else(num_cpus::get_physical);
+        let num_threads = worker_threads.get();
 
         let is_end = Arc::new(AtomicBool::new(false));
         let connections = (0..num_threads).filter_map(|i| {

--- a/src/client.rs
+++ b/src/client.rs
@@ -2204,6 +2204,7 @@ pub mod fast {
         n_tasks: usize,
         n_connections: usize,
         n_http_parallel: usize,
+        worker_threads: Option<std::num::NonZeroUsize>,
     ) {
         #[cfg(feature = "http3")]
         if matches!(client.work_type(), HttpWorkType::H3) {
@@ -2213,13 +2214,16 @@ pub mod fast {
                 n_tasks,
                 n_connections,
                 n_http_parallel,
+                worker_threads,
             )
             .await;
             return;
         }
 
         let counter = Arc::new(AtomicIsize::new(n_tasks as isize));
-        let num_threads = num_cpus::get_physical();
+        let num_threads = worker_threads
+            .map(|n| n.get())
+            .unwrap_or_else(num_cpus::get_physical);
         let connections = (0..num_threads).filter_map(|i| {
             let num_connection = n_connections / num_threads
                 + (if (n_connections % num_threads) > i {
@@ -2430,6 +2434,7 @@ pub mod fast {
         n_connections: usize,
         n_http_parallel: usize,
         wait_ongoing_requests_after_deadline: bool,
+        worker_threads: Option<std::num::NonZeroUsize>,
     ) {
         #[cfg(feature = "http3")]
         if matches!(client.work_type(), HttpWorkType::H3) {
@@ -2440,12 +2445,15 @@ pub mod fast {
                 n_connections,
                 n_http_parallel,
                 wait_ongoing_requests_after_deadline,
+                worker_threads,
             )
             .await;
             return;
         }
 
-        let num_threads = num_cpus::get_physical();
+        let num_threads = worker_threads
+            .map(|n| n.get())
+            .unwrap_or_else(num_cpus::get_physical);
 
         let is_end = Arc::new(AtomicBool::new(false));
         let connections = (0..num_threads).filter_map(|i| {

--- a/src/client_h3.rs
+++ b/src/client_h3.rs
@@ -945,12 +945,10 @@ pub mod fast {
         n_tasks: usize,
         n_connections: usize,
         n_http_parallel: usize,
-        worker_threads: Option<std::num::NonZeroUsize>,
+        worker_threads: std::num::NonZeroUsize,
     ) {
         let counter = Arc::new(AtomicIsize::new(n_tasks as isize));
-        let num_threads = worker_threads
-            .map(|n| n.get())
-            .unwrap_or_else(num_cpus::get_physical);
+        let num_threads = worker_threads.get();
         let connections = (0..num_threads).filter_map(|i| {
             let num_connection = n_connections / num_threads
                 + (if (n_connections % num_threads) > i {
@@ -1011,11 +1009,9 @@ pub mod fast {
         n_connections: usize,
         n_http_parallel: usize,
         wait_ongoing_requests_after_deadline: bool,
-        worker_threads: Option<std::num::NonZeroUsize>,
+        worker_threads: std::num::NonZeroUsize,
     ) {
-        let num_threads = worker_threads
-            .map(|n| n.get())
-            .unwrap_or_else(num_cpus::get_physical);
+        let num_threads = worker_threads.get();
 
         let is_end = Arc::new(AtomicBool::new(false));
         let connections = (0..num_threads).filter_map(|i| {

--- a/src/client_h3.rs
+++ b/src/client_h3.rs
@@ -945,9 +945,12 @@ pub mod fast {
         n_tasks: usize,
         n_connections: usize,
         n_http_parallel: usize,
+        worker_threads: Option<std::num::NonZeroUsize>,
     ) {
         let counter = Arc::new(AtomicIsize::new(n_tasks as isize));
-        let num_threads = num_cpus::get_physical();
+        let num_threads = worker_threads
+            .map(|n| n.get())
+            .unwrap_or_else(num_cpus::get_physical);
         let connections = (0..num_threads).filter_map(|i| {
             let num_connection = n_connections / num_threads
                 + (if (n_connections % num_threads) > i {
@@ -1008,8 +1011,11 @@ pub mod fast {
         n_connections: usize,
         n_http_parallel: usize,
         wait_ongoing_requests_after_deadline: bool,
+        worker_threads: Option<std::num::NonZeroUsize>,
     ) {
-        let num_threads = num_cpus::get_physical();
+        let num_threads = worker_threads
+            .map(|n| n.get())
+            .unwrap_or_else(num_cpus::get_physical);
 
         let is_end = Arc::new(AtomicBool::new(false));
         let connections = (0..num_threads).filter_map(|i| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,12 @@ Note: if used several times for the same host:port:target_host:target_port, a ra
         short = 'u'
     )]
     time_unit: Option<TimeScale>,
+    #[arg(
+        help = "Number of native OS threads used by the async runtime (tokio).
+Takes precedence over the TOKIO_WORKER_THREADS environment variable. When neither is set, the number of physical CPU cores is used.",
+        long = "worker-threads"
+    )]
+    pub worker_threads: Option<std::num::NonZeroUsize>,
 }
 
 pub async fn run(mut opts: Opts) -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,11 +333,13 @@ Note: if used several times for the same host:port:target_host:target_port, a ra
     )]
     time_unit: Option<TimeScale>,
     #[arg(
-        help = "Number of native OS threads used by the async runtime (tokio).
-Takes precedence over the TOKIO_WORKER_THREADS environment variable. When neither is set, the number of physical CPU cores is used.",
-        long = "worker-threads"
+        help = "Number of native OS threads used by the async runtime (tokio). Defaults to the number of physical CPU cores.",
+        long = "worker-threads",
+        env = "TOKIO_WORKER_THREADS",
+        default_value_t = std::num::NonZeroUsize::new(num_cpus::get_physical())
+            .unwrap_or(std::num::NonZeroUsize::MIN)
     )]
-    pub worker_threads: Option<std::num::NonZeroUsize>,
+    pub worker_threads: std::num::NonZeroUsize,
 }
 
 pub async fn run(mut opts: Opts) -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -691,6 +691,7 @@ pub async fn run(mut opts: Opts) -> anyhow::Result<()> {
                     n_requests,
                     n_connections,
                     n_http2_parallel,
+                    opts.worker_threads,
                 )
                 .await;
 
@@ -720,6 +721,7 @@ pub async fn run(mut opts: Opts) -> anyhow::Result<()> {
                     n_connections,
                     n_http2_parallel,
                     wait_ongoing_requests_after_deadline,
+                    opts.worker_threads,
                 )
                 .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,24 +2,29 @@ use clap::{CommandFactory, Parser};
 use oha::{Opts, run};
 
 fn main() {
-    let num_workers_threads = std::env::var("TOKIO_WORKER_THREADS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        // Prefer to use physical cores rather than logical one because it's more performant empirically.
-        .unwrap_or(num_cpus::get_physical());
-
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(num_workers_threads)
-        .enable_all()
-        .build()
-        .unwrap();
-
     let opts = Opts::parse();
 
     if let Some(shell) = opts.completions {
         clap_complete::generate(shell, &mut Opts::command(), "oha", &mut std::io::stdout());
         return;
     }
+
+    let num_workers_threads = opts
+        .worker_threads
+        .map(|n| n.get())
+        .or_else(|| {
+            std::env::var("TOKIO_WORKER_THREADS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+        })
+        // Prefer to use physical cores rather than logical one because it's more performant empirically.
+        .unwrap_or_else(num_cpus::get_physical);
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(num_workers_threads)
+        .enable_all()
+        .build()
+        .unwrap();
 
     if let Err(e) = rt.block_on(run(opts)) {
         eprintln!("Error: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,19 +9,8 @@ fn main() {
         return;
     }
 
-    let num_workers_threads = opts
-        .worker_threads
-        .map(|n| n.get())
-        .or_else(|| {
-            std::env::var("TOKIO_WORKER_THREADS")
-                .ok()
-                .and_then(|s| s.parse().ok())
-        })
-        // Prefer to use physical cores rather than logical one because it's more performant empirically.
-        .unwrap_or_else(num_cpus::get_physical);
-
     let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(num_workers_threads)
+        .worker_threads(opts.worker_threads.get())
         .enable_all()
         .build()
         .unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -65,6 +65,28 @@ fn test_no_color_cli_flag() {
     assert!(matches.get_flag("no_color"));
 }
 
+#[test]
+fn test_worker_threads_cli_flag() {
+    use clap::Parser;
+
+    // Unset by default.
+    let opts = oha::Opts::try_parse_from(["oha", "http://example.com"]).unwrap();
+    assert_eq!(opts.worker_threads, None);
+
+    // A positive value is parsed.
+    let opts =
+        oha::Opts::try_parse_from(["oha", "--worker-threads", "4", "http://example.com"]).unwrap();
+    assert_eq!(opts.worker_threads.map(|n| n.get()), Some(4));
+
+    // Zero and negative values are rejected.
+    assert!(
+        oha::Opts::try_parse_from(["oha", "--worker-threads", "0", "http://example.com"]).is_err()
+    );
+    assert!(
+        oha::Opts::try_parse_from(["oha", "--worker-threads", "-1", "http://example.com"]).is_err()
+    );
+}
+
 // Port 5111- is reserved for testing
 static PORT: AtomicU16 = AtomicU16::new(5111);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -69,14 +69,14 @@ fn test_no_color_cli_flag() {
 fn test_worker_threads_cli_flag() {
     use clap::Parser;
 
-    // Unset by default.
+    // Defaults to the number of physical CPU cores when unset.
     let opts = oha::Opts::try_parse_from(["oha", "http://example.com"]).unwrap();
-    assert_eq!(opts.worker_threads, None);
+    assert_eq!(opts.worker_threads.get(), num_cpus::get_physical());
 
     // A positive value is parsed.
     let opts =
         oha::Opts::try_parse_from(["oha", "--worker-threads", "4", "http://example.com"]).unwrap();
-    assert_eq!(opts.worker_threads.map(|n| n.get()), Some(4));
+    assert_eq!(opts.worker_threads.get(), 4);
 
     // Zero and negative values are rejected.
     assert!(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -913,6 +913,16 @@ async fn test_query_limit_with_time_limit() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_worker_threads_fast_mode() {
+    // --no-tui fixed-count runs go through the fast-mode workers; pinning the
+    // runtime thread count with --worker-threads must not drop any requests.
+    assert_eq!(
+        test_request_count(&["-n", "20", "--worker-threads", "2"]).await,
+        20
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_http_versions() {
     assert_eq!(get_req("/", &[]).await.version(), http::Version::HTTP_11);
     assert_eq!(


### PR DESCRIPTION
Add a `--worker-threads` flag to control the number of OS threads the async runtime uses, so the count can be set per invocation without having to export an environment variable.

`oha` already honours `TOKIO_WORKER_THREADS` when building the Tokio runtime, but there was no way to set it from the command line and it wasn't discoverable from `--help`. This adds a `--worker-threads <N>` option that surfaces the same knob. The flag takes precedence over the environment variable; when neither is set the previous default (the number of physical CPU cores) is unchanged, so existing behaviour is untouched.

Because the runtime is built before the CLI is parsed, `main` now parses `Opts` first and then builds the runtime using the resolved value. The argument is a `NonZeroUsize`, so `0` and negative values are rejected by the parser with a clear error rather than panicking inside Tokio.

Closes #574.

## Testing

- `cargo test --test tests test_worker_threads_cli_flag` — new test covering the default (unset), a valid value, and rejection of `0`/`-1`.
- `cargo build`, `cargo clippy`, `cargo fmt --check`.
- Verified manually: `oha --worker-threads 2 -n 10 --no-tui http://127.0.0.1:PORT/` runs, and `oha --help` lists the new option.
