### PR TITLE
Train PGO with duration and request-count workloads

### DIFF
--- a/pgo.js
+++ b/pgo.js
@@ -10,7 +10,8 @@ let server = null;
 
 try {
     server = Bun.spawn(['cargo', 'run', '--release', '--manifest-path', 'pgo/server/Cargo.toml']);
-    await $`cargo pgo run -- --profile pgo ${additional} -- -z 3m -c 900 --no-tui http://localhost:8888`;
+    await $`cargo pgo run -- --profile pgo ${additional} -- -z 1m -c 900 --no-tui http://localhost:8888`;
+    await $`cargo pgo run --keep-profiles -- --profile pgo ${additional} -- -n 1000000 -c 900 --no-tui http://localhost:8888`;
     await $`cargo pgo optimize build -- --profile pgo ${additional}`
 } finally {
     if (server !== null) {


### PR DESCRIPTION
The PGO training script previously collected profiles only from a duration-based run. Run both `-z 1m` and `-n 1000000`, preserving the first run's profiles with `--keep-profiles` so the optimized build uses both workloads. Both runs use 900 concurrent connections.

Validation: JavaScript syntax and `git diff --check` passed. Full PGO training was not run because `cargo-pgo` is not installed locally.
